### PR TITLE
added support for specified search paths

### DIFF
--- a/cukedoctor-maven-plugin/src/main/java/com/github/cukedoctor/mojo/CukedoctorMojo.java
+++ b/cukedoctor-maven-plugin/src/main/java/com/github/cukedoctor/mojo/CukedoctorMojo.java
@@ -93,6 +93,8 @@ public class CukedoctorMojo extends AbstractMojo {
     @Parameter(defaultValue = "false", required = false)
     boolean hideSummarySection;
 
+    @Parameter(required = false)
+    String cucumberResultPaths;
 
 
     @Parameter(property = "cukedoctor.skip", defaultValue = "false")


### PR DESCRIPTION
The purpose of my pull is to add more control over the files, which have to be parsed. Currently, there is either one file or a folder possible. In the folder case, there is no control which files are selected, cukedoctor takes all json files.
This is a problem if some of the files exist for other purposes, then there are always erroneous cases.