### PR TITLE
No default title in pdf files when user wants all formats

### DIFF
--- a/cukedoctor-maven-plugin/src/main/java/com/github/cukedoctor/mojo/CukedoctorMojo.java
+++ b/cukedoctor-maven-plugin/src/main/java/com/github/cukedoctor/mojo/CukedoctorMojo.java
@@ -216,6 +216,7 @@ public class CukedoctorMojo extends AbstractMojo {
                     revNumber(docVersion).
                     hardBreaks(hardBreaks).
                     numbered(numbered);
+            documentAttributes.docTitle(documentTitle);
             converter = Cukedoctor.instance(featuresFound, documentAttributes);
             converter.setFilename(pathToSave);//needed by docinfo, pdf-theme
             generatedFile = converter.renderDocumentation();

--- a/cukedoctor-maven-plugin/src/test/java/com/github/cukedoctor/mojo/CukedoctorMojoTest.java
+++ b/cukedoctor-maven-plugin/src/test/java/com/github/cukedoctor/mojo/CukedoctorMojoTest.java
@@ -364,6 +364,25 @@ public class CukedoctorMojoTest extends AbstractMojoTestCase {
 
     }
 
+    /**
+     * @throws Exception
+     */
+    public void testGenerateAllDocsWithNoDefaultTitleInPdf() throws Exception {
+
+        CukedoctorMojo mojo = (CukedoctorMojo) lookupMojo("execute", getTestFile("src/test/resources/html-pdf-title-docs-pom.xml"));
+
+        assertNotNull(mojo);
+        mojo.execute();
+        File pdfFile = FileUtil.loadFile(mojo.getDocumentationDir() + mojo.outputFileName + ".pdf");
+        assertThat(pdfFile).exists().hasParent("target/docs");
+        assertThat(mojo.getGeneratedFile()).
+                contains(":doctitle: Title");
+
+        File htmlFile = FileUtil.loadFile(mojo.getDocumentationDir() + mojo.outputFileName + ".html");
+        assertThat(htmlFile).exists().hasParent("target/docs");
+
+    }
+
     public void testSkipDocsGenerationTest() throws Exception {
         CukedoctorMojo mojo = (CukedoctorMojo) lookupMojo("execute", getTestFile("src/test/resources/skip-docs-pom.xml"));
         assertNotNull(mojo);

--- a/cukedoctor-maven-plugin/src/test/resources/html-pdf-title-docs-pom.xml
+++ b/cukedoctor-maven-plugin/src/test/resources/html-pdf-title-docs-pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.github.cukedoctor</groupId>
+    <artifactId>cukedoctor-mojo</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.cukedoctor</groupId>
+                <artifactId>cukedoctor-maven-plugin</artifactId>
+                <!--<version>0.1-SNAPSHOT</version>-->
+                <configuration>
+                    <project implementation="com.github.cukedoctor.mojo.stub.CukedoctorMojoStub"/>
+                    <outputFileName>documentation</outputFileName>
+                    <outputDir>docs</outputDir>
+                    <format>all</format>
+                    <toc>left</toc>
+                    <numbered>true</numbered>
+                    <documentTitle>Title</documentTitle>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
With maven plugin, when user select a <documentTitle> other than default and <format> equals "all" then title in pdf file doesn't change.
