### PR TITLE
Add standalone jar to Docker

### DIFF
--- a/cukedoctor-main/.dockerignore
+++ b/cukedoctor-main/.dockerignore
@@ -1,0 +1,1 @@
+**/*javadoc.jar

--- a/cukedoctor-main/Dockerfile
+++ b/cukedoctor-main/Dockerfile
@@ -7,5 +7,4 @@ VOLUME /output
 
 ENV JAVA_OPTS=""
 
-#ENTRYPOINT ["java", "-jar", "cukedoctor.jar"]
 ENTRYPOINT ["/entrypoint.sh"]

--- a/cukedoctor-main/Dockerfile
+++ b/cukedoctor-main/Dockerfile
@@ -1,0 +1,11 @@
+FROM openjdk:8u111-jre-alpine
+
+ADD target/cukedoctor*.jar cukedoctor.jar
+ADD docker/entrypoint.sh /
+
+VOLUME /output
+
+ENV JAVA_OPTS=""
+
+#ENTRYPOINT ["java", "-jar", "cukedoctor.jar"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/cukedoctor-main/docker/entrypoint.sh
+++ b/cukedoctor-main/docker/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec java $JAVA_OPTS -jar /cukedoctor.jar "$@"


### PR DESCRIPTION
With this commit, people will be able to run `cukedoctor` without having Java installed, just Docker. And this will make it easier to run `cukedoctor` on CIs like Gitlab CI, with DinD containers.

* **To test it:**

`cd cukedoctor-main`

`mvn -Dmaven.test.skip=true -Pfat-jar package && docker build -t cukedoctor/cukedoctor:1.2.2 -t cukedoctor/cukedoctor:latest .`

`docker run -v "$PWD:/output" cukedoctor/cukedoctor:1.2.2 -f pdf -o /output/generated_doc/output_name`

This will generate the folder `generated_doc` on current path and `output_name.adoc` and `output_name.pdf` inside `generated_doc` folder.

* You can also pass JAVA_OPTS like: `docker run -e JAVA_OPTS="-Xmx1m -Xms1m" -v "$PWD:/output" cukedoctor/cukedoctor:1.2.2 -f pdf -o /output/generated_doc/output_name` (Just for test, because it won't run, given the Xmx and Xms values)

* **What needs to be done of your part:**

-- Create `cukedoctor:cukedoctor` on Docker Hub (https://hub.docker.com/)
-- Push the images to this `cukedoctor:cukedoctor`
-- That's it.

Also, any doubts you can ask me.