### PR TITLE
Add support for disabling hardbreaks

### DIFF
--- a/cukedoctor-main/src/main/java/com/github/cukedoctor/CukedoctorMain.java
+++ b/cukedoctor-main/src/main/java/com/github/cukedoctor/CukedoctorMain.java
@@ -53,7 +53,7 @@ public class CukedoctorMain {
     @Parameter(names = "-versionLabel", description = "Version Label. Default is 'Version' ", required = false)
     private String versionLabel;
 
-    @Parameter(names = "-hardbreaks", description = "Sets asciidoctor hardbreaks attribute. Default is true ", required = false)
+    @Parameter(names = "-hardbreaks", description = "Sets asciidoctor hardbreaks attribute. Default is true ", arity = 1, required = false)
     private Boolean hardBreaks;
 
     @Parameter(names = "-docVersion", description = "Documentation version", required = false)


### PR DESCRIPTION
**Problem**
It's not possible to disable hardbreaks.

**Details**
By default hardbreaks are enabled https://github.com/rmpestano/cukedoctor/blob/0e86dedbd8498ad551ce314a219e78cbabb7ff7d/cukedoctor-main/src/main/java/com/github/cukedoctor/CukedoctorMain.java#L141-L143
Passing `-hardbreaks` to CLI sets `hardBreaks` to `true` which is the same as the default value.

**Proposed solution**
With arity set to 1 `-hardbreaks` require boolean argument as described http://jcommander.org/ 2.1 section.

**Alternative solution 1**
Keep hardbreaks enabled by default and replace `-hardbreaks` with `-nohardbreaks`.

**Alternative solution 2**
Change default to false.