### PR TITLE
Support for rendering of text attachments

### DIFF
--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Embedding.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Embedding.java
@@ -1,0 +1,37 @@
+package com.github.cukedoctor.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Embedding {
+    private String data;
+    private String mimeType;
+    private String name;
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    @JsonProperty("mime_type")
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    @JsonProperty("mime_type")
+    public void setMimeType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Step.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Step.java
@@ -23,6 +23,7 @@ public class Step {
 	@JsonProperty("doc_string")
 	private DocString docString;
 	private List<Output> output;
+	private List<Embedding> embeddings;
 
 
 	public String getName() {
@@ -97,6 +98,10 @@ public class Step {
 	public void setDocString(DocString docString) {
 		this.docString = docString;
 	}
+
+	public List<Embedding> getEmbeddings() { return embeddings; }
+
+	public void setEmbeddings(List<Embedding> embeddings) { this.embeddings = embeddings; }
 
 	public Long getDuration() {
 		if (result == null) {
@@ -179,4 +184,9 @@ public class Step {
 	public boolean hasOutput(){
 		 return output != null && !output.isEmpty();
 	}
+
+	public boolean hasEmbeddings() {
+		return embeddings != null && !embeddings.isEmpty();
+	}
 }
+

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/AttachmentSteps.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/AttachmentSteps.java
@@ -1,0 +1,131 @@
+package com.github.cukedoctor.bdd.cukedoctor;
+
+import com.github.cukedoctor.Cukedoctor;
+import com.github.cukedoctor.api.model.Feature;
+import com.github.cukedoctor.parser.FeatureParser;
+import com.github.cukedoctor.renderer.CukedoctorFeatureRenderer;
+import com.github.cukedoctor.util.StringUtil;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class AttachmentSteps {
+    private String renderedDocument;
+
+    private String disableExtensions;
+    private String hideStepTime;
+    private URL featureFile;
+
+    public AttachmentSteps() throws IOException {
+    }
+
+    @Before
+    public void before() throws IOException {
+        disableExtensions = System.getProperty("cukedoctor.disable-extensions");
+        hideStepTime = System.getProperty("HIDE_STEP_TIME");
+        renderedDocument = null;
+        featureFile = null;
+    }
+
+    @After
+    public void after() throws IOException {
+        // Assumed defaults across the test suite
+        // There is no "after all" hook in Cucumber-JVM, so somewhat wastefully they go here
+        resetProperty("cukedoctor.disable-extensions", disableExtensions);
+        resetProperty("HIDE_STEP_TIME", hideStepTime);
+    }
+
+    private void resetProperty(String name, String value) {
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
+    }
+
+    @Given("a Step has logged a string in Cucumber-JVM {double}.{int}")
+    public void a_Step_has_logged_a_string_in_Cucumber_JVM(Double double1, Integer int1) {
+        featureFile = getFeatureUrl("/com/github/cukedoctor/json-output/cucumber-jvm-6-7-0-log-string.json");
+    }
+
+    @Given("a Step has attached plain text as a string with a title in Cucumber-JVM {double}.{int}")
+    public void a_Step_has_attached_plain_text_as_a_string_with_a_title_in_Cucumber_JVM(Double double1, Integer int1) {
+        featureFile = getFeatureUrl("/com/github/cukedoctor/json-output/cucumber-jvm-6-7-0-attach-string-string-string.json");
+    }
+
+    @Given("a Step has attached plain text as a byte array with a title in Cucumber-JVM {double}.{int}")
+    public void a_Step_has_attached_plain_text_as_a_byte_array_with_a_title_in_Cucumber_JVM(Double double1, Integer int1) {
+        featureFile = getFeatureUrl("/com/github/cukedoctor/json-output/cucumber-jvm-6-7-0-attach-bytearray-string-string.json");
+    }
+
+    @Given("a Step has attached a string in CucumberJS {double}.{int}")
+    public void a_Step_has_attached_a_string_in_CucumberJS(Double double1, Integer int1) {
+        featureFile = getFeatureUrl("/com/github/cukedoctor/json-output/cucumber-js-6-0-5-attach-string.json");
+    }
+
+    @Given("a Step has attached plain text as a string in CucumberJS {double}.{int}")
+    public void a_Step_has_attached_plain_text_as_a_string_in_CucumberJS(Double double1, Integer int1) {
+        featureFile = getFeatureUrl("/com/github/cukedoctor/json-output/cucumber-js-6-0-5-attach-string-string.json");
+    }
+
+    @Given("a Step has attached plain text as a buffer in CucumberJS {double}.{int}")
+    public void a_Step_has_attached_plain_text_as_a_buffer_in_CucumberJS(Double double1, Integer int1) {
+        featureFile = getFeatureUrl("/com/github/cukedoctor/json-output/cucumber-js-6-0-5_attach-buffer-string.json");
+    }
+
+    @Given("a Step has logged a string and attached a plain text string with a title")
+    public void a_Step_has_logged_a_string_and_attached_a_plain_text_string_with_a_title() {
+        featureFile = getFeatureUrl("/com/github/cukedoctor/json-output/log-and-attach.json");
+    }
+
+    @Given("a Step has three plain text attachments, two without a title")
+    public void a_Step_has_three_plain_text_attachments_two_without_a_title() {
+        featureFile = getFeatureUrl("/com/github/cukedoctor/json-output/multiple-attachments.json");
+    }
+
+    @Given("a Step has logged an image\\/png attachment")
+    public void a_Step_has_logged_an_image_png_attachment() {
+        featureFile = getFeatureUrl("/com/github/cukedoctor/json-output/not-plain-text.json");
+    }
+
+    @Given("I am hiding step timings")
+    public void i_am_hiding_step_timings() {
+        System.setProperty("HIDE_STEP_TIME", "true");
+    }
+
+    @Given("all Cukedoctor extensions are disabled")
+    public void all_cukedoctor_extensions_are_disabled() {
+        System.setProperty("cukedoctor.disable-extensions", "true");
+    }
+
+    @When("I convert the Feature")
+    public void i_convert_the_feature() {
+        List<Feature> features = FeatureParser.parse(featureFile.getPath());
+        assertThat(features).isNotNull().hasSize(1);
+        renderedDocument = new CukedoctorFeatureRenderer().renderFeatures(features);
+    }
+
+    @Then("it will be rendered as")
+    public void it_will_be_rendered_as(String expectedDocument) {
+        assetDocumentEquals(expectedDocument);
+    }
+
+    public void assetDocumentEquals(String expectedDocument) {
+        assertEquals(StringUtil.normaliseLineEndings(expectedDocument), StringUtil.normaliseLineEndings(renderedDocument));
+    }
+
+    private URL getFeatureUrl(String path) {
+        URL featureFile = getClass().getResource(path);
+        assertThat(featureFile).isNotNull();
+        return featureFile;
+    }
+}

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/parser/FeatureParserTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/parser/FeatureParserTest.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
 
+import com.github.cukedoctor.api.model.Embedding;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -98,10 +99,43 @@ public class FeatureParserTest {
 		assertNotNull(scenarios);
 		Scenario scenario = features.get(0).getScenarioByName("Show the current version of sdkman");
 		assertThat(scenario).isNotNull();
-	  Step step = scenario.getStepByName("I see \"SDKMAN x.y.z\"");
+	  	Step step = scenario.getStepByName("I see \"SDKMAN x.y.z\"");
 		assertThat(step).isNotNull();
 		assertThat(step.getOutput()).isNotNull().hasSize(1);
 		assertThat(step.getOutput().get(0).getValue().replaceAll("\n","")).isEqualTo("Output: broadcast messageSDKMAN x.y.z");
+	}
+
+	@Test
+	public void shouldParseFeatureWithAttachments() throws IOException {
+		List<Feature> features = FeatureParser.parse("target/test-classes/json-output/attachments.json");
+		assertThat(features).hasSize(1);
+		List<Scenario> scenarios = features.get(0).getScenarios();
+		assertNotNull(scenarios);
+		Scenario scenario = features.get(0).getScenarioByName("Multiple attachments");
+		assertThat(scenario).isNotNull();
+		Step step = scenario.getStepByName("a Step that has multiple attachments");
+		assertThat(step).isNotNull();
+
+		List<Embedding> embeddings = step.getEmbeddings();
+		assertThat(embeddings).isNotNull().hasSize(3);
+
+		assertThat(embeddings.get(0))
+				.isNotNull()
+				.hasFieldOrPropertyWithValue("data", "First attachment")
+				.hasFieldOrPropertyWithValue("mimeType", "text/plain")
+				.hasFieldOrPropertyWithValue("name", null);
+
+		assertThat(embeddings.get(1))
+				.isNotNull()
+				.hasFieldOrPropertyWithValue("data", "U2Vjb25kIEF0dGFjaG1lbnQ\u003d")
+				.hasFieldOrPropertyWithValue("mimeType", "text/plain")
+				.hasFieldOrPropertyWithValue("name", "Second");
+
+		assertThat(embeddings.get(2))
+				.isNotNull()
+				.hasFieldOrPropertyWithValue("data", "Third attachment")
+				.hasFieldOrPropertyWithValue("mimeType", "text/plain")
+				.hasFieldOrPropertyWithValue("name", null);
 	}
 
 	@Test

--- a/cukedoctor-converter/src/test/resources/com/github/cukedoctor/bdd/cukedoctor/attachments.feature
+++ b/cukedoctor-converter/src/test/resources/com/github/cukedoctor/bdd/cukedoctor/attachments.feature
@@ -1,0 +1,293 @@
+Feature: Attachments
+  ====
+  [quote]
+  ____
+  In order to capture dynamically-generated content from my tests
+  As a bdd developer
+  I want to render attachments from my Cucumber tests in my living documentation
+  ____
+  ====
+
+
+  Scenario: Logging a string in Cucumber-JVM 6.7.0
+
+    Given a Step has logged a string in Cucumber-JVM 6.7.0
+    And I am hiding step timings
+    And all Cukedoctor extensions are disabled
+    When I convert the Feature
+    Then it will be rendered as
+"""asciidoc
+= *Features*
+
+
+[[Attachments, Attachments]]
+== *Attachments*
+
+=== Scenario: Cucumber JVM 6.7.0 scenario.log(String)
+
+==========
+Given ::
+a Step that performs scenario.log(String) icon:thumbs-up[role="green",title="Passed"]
+----
+She sells sea shells on the sea shore
+----
+==========
+
+
+"""
+
+  Scenario: Attaching plain text as a string with name in Cucumber-JVM 6.7.0
+
+    Given a Step has attached plain text as a string with a title in Cucumber-JVM 6.7.0
+    And I am hiding step timings
+    And all Cukedoctor extensions are disabled
+    When I convert the Feature
+    Then it will be rendered as
+"""asciidoc
+= *Features*
+
+
+[[Attachments, Attachments]]
+== *Attachments*
+
+=== Scenario: Cucumber JVM 6.7.0 scenario.attach(String, String, String)
+
+==========
+Given ::
+a Step that performs scenario.attach(String, String, String) icon:thumbs-up[role="green",title="Passed"]
+
+.String plain text
+[%collapsible]
+=====
+She sells sea shells on the sea shore
+=====
+==========
+
+
+"""
+
+
+  Scenario: Attaching plain text as a byte array with name in Cucumber-JVM 6.7.0
+
+    Given a Step has attached plain text as a byte array with a title in Cucumber-JVM 6.7.0
+    And I am hiding step timings
+    And all Cukedoctor extensions are disabled
+    When I convert the Feature
+    Then it will be rendered as
+"""asciidoc
+= *Features*
+
+
+[[Attachments, Attachments]]
+== *Attachments*
+
+=== Scenario: Cucumber JVM 6.7.0 scenario.attach(ByteArray, String, String)
+
+==========
+Given ::
+a Step that performs scenario.attach(ByteArray, String, String) icon:thumbs-up[role="green",title="Passed"]
+
+.Byte[] plain text
+[%collapsible]
+=====
+She sells sea shells on the sea shore
+=====
+==========
+
+
+"""
+
+
+  Scenario: Attaching a string CucumberJS 6.0.5
+
+    Given a Step has attached a string in CucumberJS 6.0.5
+    And I am hiding step timings
+    And all Cukedoctor extensions are disabled
+    When I convert the Feature
+    Then it will be rendered as
+"""asciidoc
+= *Features*
+
+
+[[Attachments, Attachments]]
+== *Attachments*
+
+=== Scenario: Cucumber JS 6.0.5 attach String
+
+==========
+Given ::
+a Step that performs attach String icon:thumbs-up[role="green",title="Passed"]
+
+.Attachment 1
+[%collapsible]
+=====
+She sells sea shells on the sea shore
+=====
+==========
+
+
+"""
+
+
+  Scenario: Attaching a plain text string CucumberJS 6.0.5
+
+    Given a Step has attached plain text as a string in CucumberJS 6.0.5
+    And I am hiding step timings
+    And all Cukedoctor extensions are disabled
+    When I convert the Feature
+    Then it will be rendered as
+"""asciidoc
+= *Features*
+
+
+[[Attachments, Attachments]]
+== *Attachments*
+
+=== Scenario: Cucumber JS 6.0.5 attach String, String
+
+==========
+Given ::
+a Step that performs attach String, String icon:thumbs-up[role="green",title="Passed"]
+
+.Attachment 1
+[%collapsible]
+=====
+She sells sea shells on the sea shore
+=====
+==========
+
+
+"""
+
+
+  Scenario: Attaching a plain text buffer CucumberJS 6.0.5
+
+    Given a Step has attached plain text as a buffer in CucumberJS 6.0.5
+    And I am hiding step timings
+    And all Cukedoctor extensions are disabled
+    When I convert the Feature
+    Then it will be rendered as
+"""asciidoc
+= *Features*
+
+
+[[Attachments, Attachments]]
+== *Attachments*
+
+=== Scenario: Cucumber JS 6.0.5 attach Buffer, String
+
+==========
+Given ::
+a Step that performs attach Buffer, String icon:thumbs-up[role="green",title="Passed"]
+
+.Attachment 1
+[%collapsible]
+=====
+She sells sea shells on the sea shore
+=====
+==========
+
+
+"""
+
+
+  Scenario: Logged text should appear before attachments
+
+    Given a Step has logged a string and attached a plain text string with a title
+    And I am hiding step timings
+    And all Cukedoctor extensions are disabled
+    When I convert the Feature
+    Then it will be rendered as
+"""asciidoc
+= *Features*
+
+
+[[Attachments, Attachments]]
+== *Attachments*
+
+=== Scenario: Log and attach
+
+==========
+Given ::
+a Step that logs and attaches icon:thumbs-up[role="green",title="Passed"]
+----
+Peter Piper picked a peck of pickled peppers
+----
+
+.String plain text
+[%collapsible]
+=====
+She sells sea shells on the sea shore
+=====
+==========
+
+
+"""
+
+
+  Scenario: Multiple attachments
+
+    Given a Step has three plain text attachments, two without a title
+    And I am hiding step timings
+    And all Cukedoctor extensions are disabled
+    When I convert the Feature
+    Then it will be rendered as
+"""asciidoc
+= *Features*
+
+
+[[Attachments, Attachments]]
+== *Attachments*
+
+=== Scenario: Multiple attachments
+
+==========
+Given ::
+a Step that has multiple attachments icon:thumbs-up[role="green",title="Passed"]
+
+.Attachment 1
+[%collapsible]
+=====
+First attachment
+=====
+
+.Second
+[%collapsible]
+=====
+Second Attachment
+=====
+
+.Attachment 2
+[%collapsible]
+=====
+Third attachment
+=====
+==========
+
+
+"""
+
+
+  Scenario: Do not render attachments that are not plain text
+
+    Given a Step has logged an image/png attachment
+    And I am hiding step timings
+    And all Cukedoctor extensions are disabled
+    When I convert the Feature
+    Then it will be rendered as
+"""asciidoc
+= *Features*
+
+
+[[Attachments, Attachments]]
+== *Attachments*
+
+=== Scenario: Attaching an image
+
+==========
+Given ::
+a Step that attaches an image icon:thumbs-up[role="green",title="Passed"]
+==========
+
+
+"""

--- a/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/cucumber-js-6-0-5-attach-string-string.json
+++ b/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/cucumber-js-6-0-5-attach-string-string.json
@@ -1,0 +1,41 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "Attachments",
+    "line": 1,
+    "id": "attachments",
+    "tags": [],
+    "uri": "features\\attachments.feature",
+    "elements": [
+      {
+        "id": "attachments;cucumber-jvm-6.0.5-attach-string,-string",
+        "keyword": "Scenario",
+        "line": 3,
+        "name": "Cucumber JS 6.0.5 attach String, String",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "a Step that performs attach String, String",
+            "match": {
+              "location": "step-definitions\\attachments.ts:7"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 2000000
+            },
+            "embeddings": [
+              {
+                "data": "She sells sea shells on the sea shore",
+                "mime_type": "text/plain"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/cucumber-js-6-0-5-attach-string.json
+++ b/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/cucumber-js-6-0-5-attach-string.json
@@ -1,0 +1,41 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "Attachments",
+    "line": 1,
+    "id": "attachments",
+    "tags": [],
+    "uri": "features\\attachments.feature",
+    "elements": [
+      {
+        "id": "attachments;cucumber-jvm-6.0.5-attach-string",
+        "keyword": "Scenario",
+        "line": 3,
+        "name": "Cucumber JS 6.0.5 attach String",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "a Step that performs attach String",
+            "match": {
+              "location": "step-definitions\\attachments.ts:3"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 2000000
+            },
+            "embeddings": [
+              {
+                "data": "She sells sea shells on the sea shore",
+                "mime_type": "text/plain"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/cucumber-js-6-0-5_attach-buffer-string.json
+++ b/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/cucumber-js-6-0-5_attach-buffer-string.json
@@ -1,0 +1,41 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "Attachments",
+    "line": 1,
+    "id": "attachments",
+    "tags": [],
+    "uri": "features\\attachments.feature",
+    "elements": [
+      {
+        "id": "attachments;cucumber-jvm-6.0.5-attach-buffer,-string",
+        "keyword": "Scenario",
+        "line": 3,
+        "name": "Cucumber JS 6.0.5 attach Buffer, String",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "a Step that performs attach Buffer, String",
+            "match": {
+              "location": "step-definitions\\attachments.ts:11"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 1000000
+            },
+            "embeddings": [
+              {
+                "data": "U2hlIHNlbGxzIHNlYSBzaGVsbHMgb24gdGhlIHNlYSBzaG9yZQ==",
+                "mime_type": "text/plain"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/cucumber-jvm-6-7-0-attach-bytearray-string-string.json
+++ b/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/cucumber-jvm-6-7-0-attach-bytearray-string-string.json
@@ -1,0 +1,54 @@
+[
+  {
+    "line": 1,
+    "elements": [
+      {
+        "start_timestamp": "2020-09-28T13:39:09.469Z",
+        "before": [
+          {
+            "result": {
+              "duration": 4000000,
+              "status": "passed"
+            },
+            "match": {
+              "location": "org.example.StepDefinitions.before(io.cucumber.java.Scenario)"
+            }
+          }
+        ],
+        "line": 3,
+        "name": "Cucumber JVM 6.7.0 scenario.attach(ByteArray, String, String)",
+        "description": "",
+        "id": "attachments;cucumber-jvm-6.7.0-scenario.attach(bytearray--string--string)",
+        "type": "scenario",
+        "keyword": "Scenario",
+        "steps": [
+          {
+            "embeddings": [
+              {
+                "data": "U2hlIHNlbGxzIHNlYSBzaGVsbHMgb24gdGhlIHNlYSBzaG9yZQ\u003d\u003d",
+                "mime_type": "text/plain",
+                "name": "Byte[] plain text"
+              }
+            ],
+            "result": {
+              "duration": 5000000,
+              "status": "passed"
+            },
+            "line": 5,
+            "name": "a Step that performs scenario.attach(ByteArray, String, String)",
+            "match": {
+              "location": "org.example.StepDefinitions.attach_byte_array_string_string()"
+            },
+            "keyword": "Given "
+          }
+        ]
+      }
+    ],
+    "name": "Attachments",
+    "description": "",
+    "id": "attachments",
+    "keyword": "Feature",
+    "uri": "classpath:org/example/Test.feature",
+    "tags": []
+  }
+]

--- a/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/cucumber-jvm-6-7-0-attach-string-string-string.json
+++ b/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/cucumber-jvm-6-7-0-attach-string-string-string.json
@@ -1,0 +1,54 @@
+[
+  {
+    "line": 1,
+    "elements": [
+      {
+        "start_timestamp": "2020-09-28T13:36:46.433Z",
+        "before": [
+          {
+            "result": {
+              "duration": 2000000,
+              "status": "passed"
+            },
+            "match": {
+              "location": "org.example.StepDefinitions.before(io.cucumber.java.Scenario)"
+            }
+          }
+        ],
+        "line": 3,
+        "name": "Cucumber JVM 6.7.0 scenario.attach(String, String, String)",
+        "description": "",
+        "id": "attachments;cucumber-jvm-6.7.0-scenario.attach(string--string--string)",
+        "type": "scenario",
+        "keyword": "Scenario",
+        "steps": [
+          {
+            "embeddings": [
+              {
+                "data": "U2hlIHNlbGxzIHNlYSBzaGVsbHMgb24gdGhlIHNlYSBzaG9yZQ\u003d\u003d",
+                "mime_type": "text/plain",
+                "name": "String plain text"
+              }
+            ],
+            "result": {
+              "duration": 4000000,
+              "status": "passed"
+            },
+            "line": 5,
+            "name": "a Step that performs scenario.attach(String, String, String)",
+            "match": {
+              "location": "org.example.StepDefinitions.attach_string_string_string()"
+            },
+            "keyword": "Given "
+          }
+        ]
+      }
+    ],
+    "name": "Attachments",
+    "description": "",
+    "id": "attachments",
+    "keyword": "Feature",
+    "uri": "classpath:org/example/Test.feature",
+    "tags": []
+  }
+]

--- a/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/cucumber-jvm-6-7-0-log-string.json
+++ b/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/cucumber-jvm-6-7-0-log-string.json
@@ -1,0 +1,50 @@
+[
+  {
+    "line": 1,
+    "elements": [
+      {
+        "start_timestamp": "2020-09-28T13:41:17.991Z",
+        "before": [
+          {
+            "result": {
+              "duration": 4000000,
+              "status": "passed"
+            },
+            "match": {
+              "location": "org.example.StepDefinitions.before(io.cucumber.java.Scenario)"
+            }
+          }
+        ],
+        "line": 3,
+        "name": "Cucumber JVM 6.7.0 scenario.log(String)",
+        "description": "",
+        "id": "attachments;cucumber-jvm-6.7.0-scenario.log(bytearray)",
+        "type": "scenario",
+        "keyword": "Scenario",
+        "steps": [
+          {
+            "output": [
+              "She sells sea shells on the sea shore"
+            ],
+            "result": {
+              "duration": 5000000,
+              "status": "passed"
+            },
+            "line": 5,
+            "name": "a Step that performs scenario.log(String)",
+            "match": {
+              "location": "org.example.StepDefinitions.log_string()"
+            },
+            "keyword": "Given "
+          }
+        ]
+      }
+    ],
+    "name": "Attachments",
+    "description": "",
+    "id": "attachments",
+    "keyword": "Feature",
+    "uri": "classpath:org/example/Test.feature",
+    "tags": []
+  }
+]

--- a/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/log-and-attach.json
+++ b/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/log-and-attach.json
@@ -1,0 +1,57 @@
+[
+  {
+    "line": 1,
+    "elements": [
+      {
+        "start_timestamp": "2020-09-28T13:41:17.991Z",
+        "before": [
+          {
+            "result": {
+              "duration": 4000000,
+              "status": "passed"
+            },
+            "match": {
+              "location": "org.example.StepDefinitions.before(io.cucumber.java.Scenario)"
+            }
+          }
+        ],
+        "line": 3,
+        "name": "Log and attach",
+        "description": "",
+        "id": "attachments;cucumber-jvm-6.7.0-scenario.log(bytearray)",
+        "type": "scenario",
+        "keyword": "Scenario",
+        "steps": [
+          {
+            "embeddings": [
+              {
+                "data": "U2hlIHNlbGxzIHNlYSBzaGVsbHMgb24gdGhlIHNlYSBzaG9yZQ\u003d\u003d",
+                "mime_type": "text/plain",
+                "name": "String plain text"
+              }
+            ],
+            "output": [
+              "Peter Piper picked a peck of pickled peppers"
+            ],
+            "result": {
+              "duration": 5000000,
+              "status": "passed"
+            },
+            "line": 5,
+            "name": "a Step that logs and attaches",
+            "match": {
+              "location": "org.example.StepDefinitions.log_string()"
+            },
+            "keyword": "Given "
+          }
+        ]
+      }
+    ],
+    "name": "Attachments",
+    "description": "",
+    "id": "attachments",
+    "keyword": "Feature",
+    "uri": "classpath:org/example/Test.feature",
+    "tags": []
+  }
+]

--- a/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/multiple-attachments.json
+++ b/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/multiple-attachments.json
@@ -1,0 +1,50 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "Attachments",
+    "line": 1,
+    "id": "attachments",
+    "tags": [],
+    "uri": "features\\attachments.feature",
+    "elements": [
+      {
+        "id": "attachments;cucumber-jvm-6.0.5-attach-string,-string",
+        "keyword": "Scenario",
+        "line": 3,
+        "name": "Multiple attachments",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "a Step that has multiple attachments",
+            "match": {
+              "location": "step-definitions\\attachments.ts:7"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 2000000
+            },
+            "embeddings": [
+              {
+                "data": "First attachment",
+                "mime_type": "text/plain"
+              },
+              {
+                "data": "U2Vjb25kIEF0dGFjaG1lbnQ\u003d",
+                "mime_type": "text/plain",
+                "name": "Second"
+              },
+              {
+                "data": "Third attachment",
+                "mime_type": "text/plain"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/not-plain-text.json
+++ b/cukedoctor-converter/src/test/resources/com/github/cukedoctor/json-output/not-plain-text.json
@@ -1,0 +1,41 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "Attachments",
+    "line": 1,
+    "id": "attachments",
+    "tags": [],
+    "uri": "features\\attachments.feature",
+    "elements": [
+      {
+        "id": "attachments;cucumber-jvm-6.0.5-attach-string",
+        "keyword": "Scenario",
+        "line": 3,
+        "name": "Attaching an image",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "a Step that attaches an image",
+            "match": {
+              "location": "step-definitions\\attachments.ts:3"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 2000000
+            },
+            "embeddings": [
+              {
+                "data": "U2hlIHNlbGxzIHNlYSBzaGVsbHMgb24gdGhlIHNlYSBzaG9yZQ==",
+                "mime_type": "image/png"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/cukedoctor-converter/src/test/resources/json-output/attachments.json
+++ b/cukedoctor-converter/src/test/resources/json-output/attachments.json
@@ -1,0 +1,50 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "Attachments",
+    "line": 1,
+    "id": "attachments",
+    "tags": [],
+    "uri": "features\\attachments.feature",
+    "elements": [
+      {
+        "id": "attachments;cucumber-jvm-6.0.5-attach-string,-string",
+        "keyword": "Scenario",
+        "line": 3,
+        "name": "Multiple attachments",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "a Step that has multiple attachments",
+            "match": {
+              "location": "step-definitions\\attachments.ts:7"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 2000000
+            },
+            "embeddings": [
+              {
+                "data": "First attachment",
+                "mime_type": "text/plain"
+              },
+              {
+                "data": "U2Vjb25kIEF0dGFjaG1lbnQ\u003d",
+                "mime_type": "text/plain",
+                "name": "Second"
+              },
+              {
+                "data": "Third attachment",
+                "mime_type": "text/plain"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Addresses #161.

This PR adds support for "text/*" MIME Types and assumes a UTF-8 encoding. Some suggested future work:
- Parse the MIME Type for character set/encoding parameters and parse the payload according
- Offer a dedicated SPI extension point to add support for additional MIME Types
- Support the message formatter data structures, which allow for the unambiguous determination of whether the payload is as-is or is base64-encoded. Based on Cucumber-JVM and CucumberJS's current behaviour, and the above limitation, this implementation checks if the payload is a valid base64-encoded string and, if it is, decodes it accordingly. Clearly this will not work in all cases, but the JSON format simply does not allow one to disambiguate. The [message formatter](https://github.com/cucumber/cucumber/blob/master/messages/messages.proto) adds sufficient information to the Attachment message to resolve this.