### PR TITLE
Tests to assert that null-valued document attributes do not get passed to asciidoctor

### DIFF
--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/api/DocumentAttributesTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/api/DocumentAttributesTest.java
@@ -1,0 +1,34 @@
+package com.github.cukedoctor.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Map;
+
+import static com.github.cukedoctor.util.Constants.Attributes.Name.LINKCSS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnit4.class)
+public class DocumentAttributesTest {
+    @Test
+    public void toMapMustNotIncludeAttributesWithNullValues() {
+        DocumentAttributes attributes = new DocumentAttributes();
+        attributes.setLinkCss(null);
+        Assert.assertNull(attributes.isLinkCss());
+
+        Map<String, Object> result = attributes.toMap();
+        assertThat(result).doesNotContainKey(LINKCSS.getName());
+    }
+
+    @Test
+    public void toMapMustIncludeAttributesWithNonNullValues() {
+        DocumentAttributes attributes = new DocumentAttributes();
+        attributes.setLinkCss(false);
+        Assert.assertFalse(attributes.isLinkCss());
+
+        Map<String, Object> result = attributes.toMap();
+        assertThat(result).containsKey(LINKCSS.getName());
+    }
+}


### PR DESCRIPTION
Addresses #182. Added tests missing from #183. These ensure that null-valued attributes do not get passed on the "command line" to asciidoctor.