### PR TITLE
fix(i18n): allow for single quotes to be used in features titles

### DIFF
--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorFeatureRenderer.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorFeatureRenderer.java
@@ -97,7 +97,10 @@ public class CukedoctorFeatureRenderer extends AbstractBaseRenderer implements F
             return "";
         }
         //Anchor must not have blanks neither commas to work
-        return "[[" + feature.getName().replaceAll(",", "").replaceAll(" ", "-") +
+        return "[[" + feature.getName()
+                             .replaceAll(",", "")
+                             .replaceAll("'", "-")
+                             .replaceAll(" ", "-") +
                 ", " + feature.getName() + "]]";
     }
 

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorFeatureRenderer.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorFeatureRenderer.java
@@ -49,7 +49,7 @@ public class CukedoctorFeatureRenderer extends AbstractBaseRenderer implements F
             if ((backend.toLowerCase().contains("html") || backend.toLowerCase().contains("all")) && !cukedoctorConfig.isDisableMinMaxExtension()) {
                 //used by minimax extension @see com.github.cukedoctor.extension.CukedoctorMinMaxExtension
                 builder.append("ifndef::backend-pdf[]").append(newLine());
-                builder.append("minmax::", feature.getName().replaceAll(",", "").replaceAll(" ", "-")).append("[]").newLine();
+                builder.append("minmax::", renderFeatureId(feature)).append("[]").newLine();
                 builder.append("endif::[]").append(newLine());
             }
 
@@ -96,12 +96,15 @@ public class CukedoctorFeatureRenderer extends AbstractBaseRenderer implements F
         if (isNull(feature) || not(hasText(feature.getName()))) {
             return "";
         }
+        return "[[" + renderFeatureId(feature) + ", " + feature.getName() + "]]";
+    }
+
+    protected String renderFeatureId(Feature feature) {
         //Anchor must not have blanks neither commas to work
-        return "[[" + feature.getName()
-                             .replaceAll(",", "")
-                             .replaceAll("'", "-")
-                             .replaceAll(" ", "-") +
-                ", " + feature.getName() + "]]";
+        return feature.getName()
+                      .replaceAll(",", "")
+                      .replaceAll("'", "-")
+                      .replaceAll(" ", "-");
     }
 
     protected String renderFeatureScenario(Scenario scenario, Feature feature, CukedoctorDocumentBuilder builder) {
@@ -112,6 +115,10 @@ public class CukedoctorFeatureRenderer extends AbstractBaseRenderer implements F
     }
 
     private void loadDependentRenderers() {
-        scenarioRenderer = new ServiceLoaderUtil<ScenarioRenderer>().initialise(ScenarioRenderer.class, CukedoctorScenarioRenderer.class, i18n, documentAttributes, cukedoctorConfig);
+        scenarioRenderer = new ServiceLoaderUtil<ScenarioRenderer>().initialise(ScenarioRenderer.class,
+                                                                                CukedoctorScenarioRenderer.class,
+                                                                                i18n,
+                                                                                documentAttributes,
+                                                                                cukedoctorConfig);
     }
 }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/i18n/I18nLoaderTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/i18n/I18nLoaderTest.java
@@ -24,6 +24,7 @@ public class I18nLoaderTest {
     private static List<Feature> noLanguageFeatures;
     private static List<Feature> portugueseFeatures;
     private static List<Feature> spanishFeatures;
+    private static List<Feature> frenchFeatures;
 
 
 
@@ -32,14 +33,17 @@ public class I18nLoaderTest {
         String englishFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/english.json");
         String portugueseFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/portuguese.json");
         String spanishFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/spanish.json");
+        String frenchFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/french.json");
         String noLanguageFeature = FileUtil.findJsonFile("target/test-classes/json-output/outline.json");
         englishFeatures = FeatureParser.parse(englishFeature);
         portugueseFeatures = FeatureParser.parse(portugueseFeature);
         spanishFeatures = FeatureParser.parse(spanishFeature);
+        frenchFeatures = FeatureParser.parse(frenchFeature);
         noLanguageFeatures = FeatureParser.parse(noLanguageFeature);
         assertNotNull(englishFeatures);
         assertNotNull(portugueseFeatures);
         assertNotNull(spanishFeatures);
+        assertNotNull(frenchFeatures);
         assertNotNull(noLanguageFeatures);
     }
 
@@ -70,6 +74,14 @@ public class I18nLoaderTest {
         assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Características");
         assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumen");
         assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Pasos");
+    }
+
+    @Test
+    public void shouldLoadFrenchBundle(){
+        I18nLoader i18nLoader = I18nLoader.newInstance(frenchFeatures);
+        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Fonctionnalités");
+        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Sommaire");
+        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Étapes");
     }
 
     @Test

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/renderer/CukedoctorFeatureRendererTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/renderer/CukedoctorFeatureRendererTest.java
@@ -509,4 +509,25 @@ public class CukedoctorFeatureRendererTest {
                 .renderFeature(feature, CukedoctorDocumentBuilder.Factory.newInstance().createNestedBuilder());
         assertThat(resultDoc).contains(descriptionWithListing);
     }
+
+    @Test
+    public void shouldRenderFeaturesIncludingSingleQuotes() {
+        final Feature feature = FeatureBuilder.instance()
+                                              .description("Feature description")
+                                              .name("L'API Open API est disponible sur demande")
+                                              .build();
+        final String resultDoc = new CukedoctorFeatureRenderer(new DocumentAttributes())
+                .renderFeature(feature, CukedoctorDocumentBuilder.Factory.newInstance().createNestedBuilder());
+        assertThat(resultDoc).isEqualTo("[[L-API-Open-API-est-disponible-sur-demande, " +
+                                        "L'API Open API est disponible sur demande]]" + newLine() +
+                                        "== *L'API Open API est disponible sur demande*" + newLine() +
+                                        "" + newLine() +
+                                        "ifndef::backend-pdf[]" + newLine() +
+                                        "minmax::L-API-Open-API-est-disponible-sur-demande[]" + newLine() +
+                                        "endif::[]" + newLine() +
+                                        "****" + newLine() +
+                                        "Feature description" + newLine() +
+                                        "****" + newLine() +
+                                        "" + newLine());
+    }
 }

--- a/cukedoctor-converter/src/test/resources/json-output/i18n/french.json
+++ b/cukedoctor-converter/src/test/resources/json-output/i18n/french.json
@@ -1,0 +1,66 @@
+[
+  {
+    "comments": [
+      {
+        "line": 1,
+        "value": "# language: fr"
+      }
+    ],
+    "line": 2,
+    "elements": [
+      {
+        "start_timestamp": "2022-07-21T08:24:32.069Z",
+        "line": 11,
+        "name": "L'API Open API est disponible sur demande",
+        "description": "",
+        "id": "l-api-swagger-est-disponible;l-api-open-api-est-disponible-sur-demande",
+        "type": "scenario",
+        "keyword": "Scénario",
+        "steps": [
+          {
+            "result": {
+              "duration": 148430000,
+              "status": "passed"
+            },
+            "line": 12,
+            "name": "l'application est active",
+            "match": {
+              "location": "org.rdlopes.cukedoctor.features.steps.RestOperationsSteps.applicationIsUp()"
+            },
+            "keyword": "Etant donné que "
+          },
+          {
+            "result": {
+              "duration": 274399000,
+              "status": "passed"
+            },
+            "line": 13,
+            "name": "je demande à obtenir les spécifications de l'API",
+            "match": {
+              "location": "org.rdlopes.cukedoctor.features.steps.RestOperationsSteps.iRequestTheOpenAPISpecifications()"
+            },
+            "keyword": "Quand "
+          },
+          {
+            "result": {
+              "duration": 4886000,
+              "status": "passed"
+            },
+            "line": 14,
+            "name": "je reçois les spécifications",
+            "match": {
+              "location": "org.rdlopes.cukedoctor.features.steps.RestOperationsSteps.iReceiveTheSpecsForTheApplication()"
+            },
+            "keyword": "Alors "
+          }
+        ]
+      }
+    ],
+    "name": "L'API Swagger est disponible",
+    "description": "  [quote]\n  ====\n  En tant que développeur,\n  je veux pouvoir accéder aux spécifications de l'Open API\n  afin de comprendre comment interagir avec l'application\n  ====",
+    "id": "l-api-swagger-est-disponible",
+    "keyword": "Fonctionnalité",
+    "uri": "classpath:features/01_plateforme/01_documentation.feature",
+    "tags": []
+  }
+]

--- a/cukedoctor-maven-plugin/pom.xml
+++ b/cukedoctor-maven-plugin/pom.xml
@@ -33,7 +33,8 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>2.0</version>
+            <version>3.3.3</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
I'm a French user of Cukedoctor and I have noticed that I cannot use single quotes in the feature's title.
This PR fixes the single quote problem by replacing single quotes with "-" (dash) characters.