### PR TITLE
Set the language with a tag @language-<language>

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,10 +29,10 @@ image:https://sonarcloud.io/api/project_badges/measure?project=com.github.cukedo
 
 BDD living documentation using http://cukes.info/[Cucumber] and http://asciidoctor.org[Asciidoctor] based on Cucumber http://www.relishapp.com/cucumber/cucumber/docs/formatters/json-output-formatter[JSON execution output].
 
- 
+
 [.text-right]
 https://goo.gl/Yp3NiU[Read this page in asciidoc for better reading experience]
-  
+
 
 == Narrative
 
@@ -190,6 +190,21 @@ Cucumber feature languages are provided via comments in a feature file, https://
 
 If your feature language is *not* supported by Cukedoctor you can https://github.com/rmpestano/cukedoctor/tree/master/cukedoctor-converter/src/main/resources/i18n[contribute it here^] or use a custom bundle.
 
+Another way of setting the language is by using the `@language-<language>` tag:
+
+.i18n.feature.tag
+----
+@language-fr
+Fonctionnalité: Calculateur
+
+  Scénario: Addition de nombres
+
+----
+
+WARNING: Please notice that the tag `@language-<language>` is not part of Cucumber.
+Meaning that you still need to setup Cucumber for i18n. the `@language-<language>` tag is part of Cukedoctor and serves as a
+convenient replacement for the `# language: <language>` comment, which is not supported anymore by Cucumber in JSON files.
+
 ==== Custom resource bundle
 
 Another way of internationalization is to provide a custom bundle.
@@ -223,7 +238,7 @@ result.missing = Missing
 
 ==== Supported locales
 
-Cukdoctor currently supports the following locales *en*, *es*, *fr*, *ge* and *pt*.
+Cukedoctor currently supports the following locales *en*, *es*, *fr*, *ge* and *pt*.
 
 Here are the https://github.com/rmpestano/cukedoctor/tree/master/cukedoctor-converter/src/main/resources[supported locales^]
 
@@ -761,11 +776,11 @@ mvn cukedoctor:execute
 |false
 
 |featuresDir
-|Directory to start searching (recursively) for cucumber json output  
+|Directory to start searching (recursively) for cucumber json output
 |project root directory
 
 |disableFilter
-|When present, this flag disables features filtering 
+|When present, this flag disables features filtering
 |
 
 |disableMinimizable
@@ -1050,7 +1065,7 @@ docker run -v "$PWD:/output" rmpestano/cukedoctor -f pdf -o /output/generated_do
 
 It will search features (cucumber output in json format) in current folder (`$PWD`) and generate living documentation in  `/output/generated_doc`
 
-TIP: To change features folder just change first parameter of docker volume, ex: `docker run -v "/home:/output" ...` will search for cucumber features in `/home` directory.  
+TIP: To change features folder just change first parameter of docker volume, ex: `docker run -v "/home:/output" ...` will search for cucumber features in `/home` directory.
 
 NOTE: For Cukedoctor parameters details, see https://github.com/rmpestano/cukedoctor#usage-2[cukedoctor-cli^]
 

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/StepResults.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/StepResults.java
@@ -14,9 +14,9 @@ import com.github.cukedoctor.util.Formatter;
 public class StepResults {
 
 
-	private List<Step> allSteps;
-	private Map<Status, AtomicInteger> statusCounter;
-	private long totalDuration;
+	private final List<Step> allSteps;
+	private final Map<Status, AtomicInteger> statusCounter;
+	private final long totalDuration;
 
 	public StepResults(List<Step> allSteps, Map<Status, AtomicInteger> statusCounter, long totalDuration) {
 		this.allSteps = allSteps;

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Comment.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Comment.java
@@ -51,7 +51,6 @@ public class Comment {
 
     @Override
     public String toString() {
-        // TODO Auto-generated method stub
         return value;
     }
 }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Feature.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Feature.java
@@ -23,7 +23,7 @@ public class Feature implements Comparable<Feature> {
     private String description;
     private String keyword;
     private List<Scenario> elements = new ArrayList<>();
-    private List<Scenario> scenarios = new ArrayList<>();
+    private final List<Scenario> scenarios = new ArrayList<>();
     private List<Tag> tags = new ArrayList<>();
     private StepResults stepResults;
     private ScenarioResults scenarioResults;
@@ -136,26 +136,6 @@ public class Feature implements Comparable<Feature> {
         this.backgroundRendered = backgroundRendered;
     }
 
-
-    /**
-     * @return total number of scenarios
-     * @deprecated use {@link Feature#getScenarioResults()}
-     */
-    @Deprecated
-    public Integer getNumberOfScenarios() {
-        Integer result = 0;
-        if (scenarios != null) {
-            List<Scenario> elementList = new ArrayList<Scenario>();
-            for (Scenario element : scenarios) {
-                if (!element.hasExamples()) {
-                    elementList.add(element);
-                }
-            }
-            result = elementList.size();
-        }
-        return result;
-    }
-
     public Integer getNumberOfSteps() {
         return stepResults.getNumberOfSteps();
     }
@@ -202,38 +182,33 @@ public class Feature implements Comparable<Feature> {
 
     public void initScenarios() {
         if (elements != null) {
-            for (Scenario element : elements) {
-                scenarios.add(element);
-            }
+            scenarios.addAll(elements);
         }
-
     }
 
     public void processSteps() {
         if (!isCucumberFeature()) {
             return;
         }
-        List<Step> allSteps = new ArrayList<Step>();
+        List<Step> allSteps = new ArrayList<>();
         Map<Status, AtomicInteger> statusCounter = new HashMap<>();
         for (Status status : Status.values()) {
             statusCounter.put(status, new AtomicInteger(0));
         }
-        List<Scenario> passedScenarios = new ArrayList<Scenario>();
-        List<Scenario> failedScenarios = new ArrayList<Scenario>();
+        List<Scenario> passedScenarios = new ArrayList<>();
+        List<Scenario> failedScenarios = new ArrayList<>();
         long totalDuration = 0L;
 
-        if (scenarios != null) {
-            for (Scenario scenario : scenarios) {
-                if (scenario.hasExamples()) {
-                    continue;
-                }
-                calculateScenarioStats(passedScenarios, failedScenarios, scenario);
-                if (scenario.hasSteps()) {
-                    for (Step step : scenario.getSteps()) {
-                        allSteps.add(step);
-                        statusCounter.get(step.getStatus()).incrementAndGet();
-                        totalDuration += step.getDuration();
-                    }
+        for (Scenario scenario : scenarios) {
+            if (scenario.hasExamples()) {
+                continue;
+            }
+            calculateScenarioStats(passedScenarios, failedScenarios, scenario);
+            if (scenario.hasSteps()) {
+                for (Step step : scenario.getSteps()) {
+                    allSteps.add(step);
+                    statusCounter.get(step.getStatus()).incrementAndGet();
+                    totalDuration += step.getDuration();
                 }
             }
         }
@@ -332,7 +307,7 @@ public class Feature implements Comparable<Feature> {
 
         Feature feature = (Feature) o;
 
-        return !(id != null ? !id.equals(feature.id) : feature.id != null);
+        return Objects.equals(id, feature.id);
 
     }
 

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Feature.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Feature.java
@@ -260,12 +260,16 @@ public class Feature implements Comparable<Feature> {
     public String getLanguage() {
         if (language == null && comments != null) {
             for (Comment comment : comments) {
-                final Optional<String> lang = comment.getLanguage();
-                if (lang.isPresent() && hasText(lang.get())) {
-                    language = lang.get();
-                }
+                trySetLanguage(comment.getLanguage(), "comment");
             }
         }
+
+        if (language == null && hasTags()) {
+            for (Tag tag : getTags()) {
+                trySetLanguage(tag.getLanguage(), "tag");
+            }
+        }
+
         if (language == null) {
             this.language = "";
         }
@@ -298,7 +302,25 @@ public class Feature implements Comparable<Feature> {
             try {
                 this.order = Integer.parseInt(order.get());
             } catch (Exception e) {
-                Logger.getLogger(getClass().getName()).warning(String.format("Could not get order of feature %s from %s cause: %s", name, source, e.getMessage()));
+                Logger.getLogger(getClass().getName())
+                      .warning(String.format("Could not get order of feature %s from %s cause: %s",
+                                             name,
+                                             source,
+                                             e.getMessage()));
+            }
+        }
+    }
+
+    private void trySetLanguage(Optional<String> language, String source) {
+        if (language.isPresent() && hasText(language.get())) {
+            try {
+                this.language = language.get();
+            } catch (Exception e) {
+                Logger.getLogger(getClass().getName())
+                      .warning(String.format("Could not get language of feature %s from %s cause: %s",
+                                             name,
+                                             source,
+                                             e.getMessage()));
             }
         }
     }
@@ -369,9 +391,9 @@ public class Feature implements Comparable<Feature> {
             return Optional.empty();
         }
         return getTags().stream()
-                .map(tag -> tag.extractPattern(pattern))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .findFirst();
+                        .map(tag -> tag.extractPattern(pattern))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .findFirst();
     }
 }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Scenario.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Scenario.java
@@ -6,7 +6,6 @@ import com.github.cukedoctor.util.Constants;
 import java.util.List;
 
 import static com.github.cukedoctor.util.Assert.hasText;
-import static com.github.cukedoctor.util.Assert.notEmpty;
 
 /**
  * represents a scenario is most of the cases but can be also a background

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Tag.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Tag.java
@@ -39,6 +39,10 @@ public class Tag {
         return extractPattern("@order-");
     }
 
+    public Optional<String> getLanguage() {
+        return extractPattern("@language-");
+    }
+
     public boolean isDiscrete() {
         return extractPattern("@asciidoc").isPresent();
     }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Tag.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Tag.java
@@ -35,6 +35,10 @@ public class Tag {
         return getOrder().isPresent();
     }
 
+    public boolean isLanguage() {
+        return getLanguage().isPresent();
+    }
+
     public Optional<String> getOrder() {
         return extractPattern("@order-");
     }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Type.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Type.java
@@ -7,6 +7,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
  */
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum Type {
-	scenario, scenario_outline, background;
+	scenario, scenario_outline, background
 
 }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/builder/AttributesBuilderImpl.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/builder/AttributesBuilderImpl.java
@@ -11,7 +11,7 @@ import static com.github.cukedoctor.util.Assert.hasText;
  */
 public class AttributesBuilderImpl implements AttributesBuilder {
 
-    private AsciiDocBuilder docBuilder;
+    private final AsciiDocBuilder docBuilder;
 
     public AttributesBuilderImpl(AsciiDocBuilder docBuilder) {
         this.docBuilder = docBuilder;

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/builder/CukedoctorDocumentBuilderImpl.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/builder/CukedoctorDocumentBuilderImpl.java
@@ -49,7 +49,7 @@ public class CukedoctorDocumentBuilderImpl extends AsciiDocBuilder implements Cu
         if (notEmpty(text)) {
             for (Object o : text) {
                 if (o.equals(Constants.newLine()) || hasText(o.toString())) {
-                    documentBuilder.append(o.toString());
+                    documentBuilder.append(o);
                 }
             }
         }
@@ -144,13 +144,13 @@ public class CukedoctorDocumentBuilderImpl extends AsciiDocBuilder implements Cu
     }
 
 
-    public class NestingOverflowException extends RuntimeException {
+    public static class NestingOverflowException extends RuntimeException {
         public NestingOverflowException() {
             super("Nesting is currently at Section Title Level 5 (the deepest AsciiDoc allows). You cannot nest further titles below this level.");
         }
     }
 
-    public class NestingUnderflowException extends RuntimeException {
+    public static class NestingUnderflowException extends RuntimeException {
         public NestingUnderflowException(int currentLevel) {
             super(String.format("Nesting is current at Level %s, the top-most allowed for this instance. You cannot un-nest above this level.", currentLevel));
         }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/converter/CukedoctorConverterImpl.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/converter/CukedoctorConverterImpl.java
@@ -30,15 +30,15 @@ import static com.github.cukedoctor.util.Constants.newLine;
 public class CukedoctorConverterImpl implements CukedoctorConverter {
 
 
-    private List<Feature> features;
-    private DocumentAttributes documentAttributes;
+    private final List<Feature> features;
+    private final DocumentAttributes documentAttributes;
     private String filename;
-    private CukedoctorDocumentBuilder docBuilder;
-    private I18nLoader i18n;
+    private final CukedoctorDocumentBuilder docBuilder;
+    private final I18nLoader i18n;
     private SummaryRenderer summaryRenderer;
     private FeatureRenderer featureRenderer;
     private HeaderRenderer headerRenderer;
-    private CukedoctorConfig cukedoctorConfig;
+    private final CukedoctorConfig cukedoctorConfig;
 
 
     public CukedoctorConverterImpl(List<Feature> features, DocumentAttributes attrs) {
@@ -100,7 +100,7 @@ public class CukedoctorConverterImpl implements CukedoctorConverter {
 
     private void renderIntro() {
         List<String> files = FileUtil.findFiles(cukedoctorConfig.getIntroChapterDir(), "cukedoctor-intro.adoc", true, cukedoctorConfig.getIntroChapterRelativePath());
-        if (files != null && !files.isEmpty()) {
+        if (!files.isEmpty()) {
             String introPath = files.get(0);
             introPath = introPath.replaceAll("\\\\", "/");
             docBuilder.append("include::", introPath, "[leveloffset=+1]", newLine(), newLine());

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/i18n/I18nLoader.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/i18n/I18nLoader.java
@@ -4,6 +4,7 @@ import com.github.cukedoctor.api.model.Feature;
 import com.github.cukedoctor.util.FileUtil;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.text.MessageFormat;
 import java.util.*;
 import java.util.logging.Level;
@@ -98,12 +99,12 @@ public class I18nLoader extends ResourceBundle.Control{
      */
     private InputStream findCukedoctorProperties(String baseDir) {
         List<String> files = FileUtil.findFiles(baseDir,"cukedoctor.properties",true);
-        if(files != null && !files.isEmpty()){
+        if(!files.isEmpty()){
             String path = files.get(0);
             log.fine("Loading cukedoctor resource bundle from: " + path);
             File file = new File(path);
             try {
-                return new FileInputStream(file);
+                return Files.newInputStream(file.toPath());
             } catch (Exception e) {
                 log.log(Level.WARNING, "Could not load resource bundle from target folder", e);
             }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/i18n/I18nLoader.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/i18n/I18nLoader.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
 import com.github.cukedoctor.util.Constants;
 
 import static com.github.cukedoctor.util.Assert.hasText;
+import static java.nio.charset.StandardCharsets.*;
 
 /**
  * This class is responsible for internationalization.
@@ -23,7 +24,7 @@ import static com.github.cukedoctor.util.Assert.hasText;
 public class I18nLoader extends ResourceBundle.Control{
 
     private static I18nLoader instance;
-    private static Logger log = Logger.getLogger(I18nLoader.class.getName());
+    private static final Logger log = Logger.getLogger(I18nLoader.class.getName());
 
     private ResourceBundle bundle;
 
@@ -70,11 +71,12 @@ public class I18nLoader extends ResourceBundle.Control{
                 stream = I18nLoader.class.getResourceAsStream(resourceName);
             }
             try {
-                bundle = new PropertyResourceBundle(new InputStreamReader(stream, "UTF-8"));
+                bundle = new PropertyResourceBundle(new InputStreamReader(stream, UTF_8));
             } catch (Exception e) {
                 log.warning(String.format("No resource bundle found for language %s. Using 'cukedoctor_en.properties' as default bundle.", lang));
                 try {
-                    bundle = new PropertyResourceBundle(new InputStreamReader(I18nLoader.class.getResourceAsStream("/i18n/cukedoctor_en.properties"), "UTF-8"));
+                    bundle = new PropertyResourceBundle(new InputStreamReader(I18nLoader.class.getResourceAsStream("/i18n/cukedoctor_en.properties"),
+                                                                              UTF_8));
                 } catch (Exception e1) {
                     throw new RuntimeException("Could not find cukedoctor resource bundle",e1);
                 }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/markup/Asciidoc.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/markup/Asciidoc.java
@@ -11,7 +11,7 @@ public enum Asciidoc implements Markup {
 
     private final String markup;
 
-    private Asciidoc(String markup) {
+    Asciidoc(String markup) {
         this.markup = markup;
     }
 

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/parser/FeatureParser.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/parser/FeatureParser.java
@@ -8,6 +8,7 @@ import com.github.cukedoctor.api.model.Feature;
 import com.github.cukedoctor.util.FileUtil;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -25,7 +26,7 @@ public class FeatureParser {
 	 */
 	public static List<Feature> parse(String json) {
 		List<Feature> features = null;
-		try (InputStreamReader is = new InputStreamReader(new FileInputStream(json),"UTF-8")) {
+		try (InputStreamReader is = new InputStreamReader(new FileInputStream(json), StandardCharsets.UTF_8)) {
 			features = new ObjectMapper().readValue(is, new TypeReference<List<Feature>>() {
 			});
 			Iterator<Feature> it = features.iterator();

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorStepsRenderer.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorStepsRenderer.java
@@ -191,7 +191,7 @@ public class CukedoctorStepsRenderer extends AbstractBaseRenderer implements Ste
                 continue;
             }
 
-            if(!isListing && line.contains("----")){
+            if(line.contains("----")){
                 isListing = true;
                 docBuilder.textLine(line);
                 continue;
@@ -202,12 +202,12 @@ public class CukedoctorStepsRenderer extends AbstractBaseRenderer implements Ste
                 docBuilder.textLine(line);
                 continue;
             }
-            //do not add discrete to complex blocks otherwise it will produce invalid markup like below:
             /**
+             * do not add discrete to complex blocks otherwise it will produce invalid markup like below:
              * [discrete]
-               [IMPORTANT]
-               [discrete]
-                ======
+             * [IMPORTANT]
+             * [discrete]
+             * ======
              */
             if(line.startsWith("======")){
                 docBuilder.textLine(line);

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorTagsRenderer.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorTagsRenderer.java
@@ -52,6 +52,6 @@ public class CukedoctorTagsRenderer extends AbstractBaseRenderer implements Tags
     }
 
     protected boolean isCukedoctorTag(Tag tag) {
-        return tag.isOrder() || tag.isDiscrete();
+        return tag.isOrder() || tag.isLanguage() || tag.isDiscrete();
     }
 }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/util/Assert.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/util/Assert.java
@@ -2,7 +2,6 @@ package com.github.cukedoctor.util;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.Map;
 
 /**
  * Created by rafael-pestano on 26/06/2015.
@@ -45,10 +44,7 @@ public class Assert implements Serializable {
    * @return TRUE when given text has any character, FALSE otherwise
    */
   public static boolean hasText(String text) {
-    if (notNull(text) && text.trim().length() > 0) {
-      return true;
-    }
-    return false;
+      return notNull(text) && text.trim().length() > 0;
   }
 
   /**
@@ -58,10 +54,7 @@ public class Assert implements Serializable {
    * otherwise
    */
   public static boolean contains(String textToSearch, String substring) {
-    if (notNull(textToSearch) && textToSearch.contains(substring)) {
-      return true;
-    }
-    return false;
+      return notNull(textToSearch) && textToSearch.contains(substring);
   }
 
   /**
@@ -87,11 +80,7 @@ public class Assert implements Serializable {
    * {@code null} and must have at least one element. @return  FALSE otherwise
    */
   public static boolean notEmpty(Collection<?> collection) {
-    if (notNull(collection) && !collection.isEmpty()) {
-      return true;
-    } else {
-      return false;
-    }
+      return notNull(collection) && !collection.isEmpty();
   }
 
   /**
@@ -100,14 +89,6 @@ public class Assert implements Serializable {
    * otherwise
    */
   public static boolean hasElements(Object[] array) {
-    if(array == null || array.length > 0){
-      return false;
-    }
-    for (Object o : array) {
-      if(o != null){
-        return true;
-      }
-    }
     return false;
   }
 
@@ -116,7 +97,7 @@ public class Assert implements Serializable {
    * @return TRUE when given array has at least one not null element;  FALSE
    * otherwise
    */
-  public static boolean hasElements(Collection array) {
+  public static boolean hasElements(Collection<?> array) {
     if(array == null || array.isEmpty()){
       return false;
     }
@@ -128,33 +109,15 @@ public class Assert implements Serializable {
     return false;
   }
 
-
-  /**
-   * @param map to check emptiness
-   * @return TRUE if given Map has entries; that is, it must not be {@code null}
-   * and must have at least one entry. Queue FALSE otherwise
-   */
-  public static boolean notEmpty(Map<?, ?> map) {
-    if (map == null) {
-      return false;
-    }
-    if (hasElements(map.entrySet().toArray())) {
-      return true;
-    }
-    return false;
-  }
-
   /**
    * Assert that an array has no null elements. Note: Does not complain if the
    * array is empty!
-   * 
+   *
    * <pre class="code">
    * Assert.noNullElements(array, &quot;The array must have non-null elements&quot;);
    * </pre>
-   * 
+   *
    * @param array the array
-   */
-  /**
    * @return TRUE when given array has no null elements; FALSE otherwise
    */
   public static boolean notNull(Object[] array) {

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/util/Constants.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/util/Constants.java
@@ -122,7 +122,7 @@ public abstract class Constants {
                 }
                 adocAttr.append(attrName).append(":");
             } else {
-                adocAttr.append(attrName).append(":").append(" ").append(attrValue.toString());
+                adocAttr.append(attrName).append(":").append(" ").append(attrValue);
             }
             return adocAttr.toString();
         }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/util/StringUtil.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/util/StringUtil.java
@@ -30,11 +30,8 @@ public class StringUtil {
             line = trimStart(line, leadingWhitespaceCharsToTrim);
 
             if (line.trim().startsWith(Constants.Markup.listing())) {
-                if (shouldTrim) {
-                    shouldTrim = false;//remove trimming on start listing
-                } else {
-                    shouldTrim = true; //enable trimming on end listing
-                }
+                //enable trimming on end listing
+                shouldTrim = !shouldTrim;//remove trimming on start listing
             }
 
             if (shouldTrim) {

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/util/builder/FeatureBuilder.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/util/builder/FeatureBuilder.java
@@ -10,7 +10,7 @@ import java.util.List;
  */
 public class FeatureBuilder {
 
-	private Feature feature;
+	private final Feature feature;
 	private static FeatureBuilder instance;
 
 
@@ -54,9 +54,7 @@ public class FeatureBuilder {
 	}
 
 	public FeatureBuilder scenario(Scenario scenario) {
-		if (feature.getElements() == null) {
-			feature.setElements(new ArrayList<Scenario>());
-		}
+		if (feature.getElements() == null) feature.setElements(new ArrayList<>());
 		feature.getElements().add(scenario);
 		return instance;
 	}
@@ -85,35 +83,28 @@ public class FeatureBuilder {
 	}
 
 	public Feature aFeatureWithTwoScenarios() {
-
-		final Feature feature = FeatureBuilder.instance().description("Feature description").
-				scenario(ScenarioBuilder.instance().name("scenario 1").description("description")
+		return FeatureBuilder.instance().description("Feature description").
+							 scenario(ScenarioBuilder.instance().name("scenario 1").description("description")
 						.keyword("Scenario").type(Type.scenario).build()).
-				scenario(ScenarioBuilder.instance().name("scenario 2").description("description 2")
+							 scenario(ScenarioBuilder.instance().name("scenario 2").description("description 2")
 						.keyword("Scenario").type(Type.scenario).build()).
-				name("Feature name").build();
-
-		return feature;
+							 name("Feature name").build();
 	}
 
 	public Feature aFeatureWithOneScenarioWithOnePassingStep() {
-
-		final Feature feature = FeatureBuilder.instance().description("Feature description").
-				scenario(ScenarioBuilder.instance().name("scenario").description("description")
+		return FeatureBuilder.instance().description("Feature description").
+							 scenario(ScenarioBuilder.instance().name("scenario").description("description")
 						.keyword("Scenario").type(Type.scenario).
 								step(StepBuilder.instance().name("passing step")
 										.result(new Result(Status.passed))
 										.keyword("Given").build()). //step
 								build()).//build scenario
 				name("Feature name").build();
-
-		return feature;
 	}
 
 	public Feature aFeatureWithOneScenarioWithOnePassingAndOneFailingStep() {
-
-		final Feature feature = FeatureBuilder.instance().description("Feature description").
-				scenario(ScenarioBuilder.instance().name("scenario").description("description")
+		return FeatureBuilder.instance().description("Feature description").
+							 scenario(ScenarioBuilder.instance().name("scenario").description("description")
 						.keyword("Scenario").type(Type.scenario).
 								step(StepBuilder.instance().name("passing step")
 										.result(new Result(Status.passed))
@@ -125,14 +116,11 @@ public class FeatureBuilder {
 										.keyword("When").build()).
 								build()).//build scenario
 				name("Feature name").build();
-
-		return feature;
 	}
 
 	public Feature aFeatureWithOneScenarioWithMultipleSteps() {
-
-		final Feature feature = FeatureBuilder.instance().description("Feature description").
-				scenario(ScenarioBuilder.instance().name("scenario").description("description")
+		return FeatureBuilder.instance().description("Feature description").
+							 scenario(ScenarioBuilder.instance().name("scenario").description("description")
 						.keyword("Scenario").type(Type.scenario).
 								step(StepBuilder.instance().name("passing step")
 										.result(new Result(Status.passed))
@@ -159,9 +147,7 @@ public class FeatureBuilder {
 										.match(new Match("match 6"))
 										.keyword("Then").build()).
 								build()).
-				name("Feature name").build();
-
-		return feature;
+							 name("Feature name").build();
 	}
 
 	public Feature aFeatureWithMultipleScenariosAndSteps() {
@@ -193,12 +179,11 @@ public class FeatureBuilder {
 								.keyword("Given").build()).
 						build();
 
-		final Feature feature = FeatureBuilder.instance().description("Feature description").
-				scenario(scenario1).
-				scenario(scenario2).
-				scenario(scenario3).
-				name("Feature name").build();
-		return feature;
+		return FeatureBuilder.instance().description("Feature description").
+							 scenario(scenario1).
+							 scenario(scenario2).
+							 scenario(scenario3).
+							 name("Feature name").build();
 
 	}
 

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/util/builder/ScenarioBuilder.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/util/builder/ScenarioBuilder.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
  */
 public class ScenarioBuilder {
 
-	private Scenario scenario;
+	private final Scenario scenario;
 	private static ScenarioBuilder instance;
 
 
@@ -59,7 +59,7 @@ public class ScenarioBuilder {
 
 	public ScenarioBuilder step(Step step) {
 		if(instance.getScenario().getSteps() == null){
-			instance.getScenario().setSteps(new ArrayList<Step>());
+			instance.getScenario().setSteps(new ArrayList<>());
 		}
 
 		if(!instance.getScenario().getSteps().contains(step)){
@@ -70,7 +70,7 @@ public class ScenarioBuilder {
 
 	public ScenarioBuilder tag(Tag tag) {
 		if(instance.getScenario().getTags() == null){
-			instance.getScenario().setTags(new ArrayList<Tag>());
+			instance.getScenario().setTags(new ArrayList<>());
 		}
 
 		if(!instance.getScenario().getTags().contains(tag)){

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/util/builder/StepBuilder.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/util/builder/StepBuilder.java
@@ -10,7 +10,7 @@ import com.github.cukedoctor.api.model.Step;
  */
 public class StepBuilder {
 
-	private Step step;
+	private final Step step;
 	private static StepBuilder instance;
 
 

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/AttachmentSteps.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/AttachmentSteps.java
@@ -1,6 +1,5 @@
 package com.github.cukedoctor.bdd.cukedoctor;
 
-import com.github.cukedoctor.Cukedoctor;
 import com.github.cukedoctor.api.model.Feature;
 import com.github.cukedoctor.parser.FeatureParser;
 import com.github.cukedoctor.renderer.CukedoctorFeatureRenderer;
@@ -25,11 +24,11 @@ public class AttachmentSteps {
     private String hideStepTime;
     private URL featureFile;
 
-    public AttachmentSteps() throws IOException {
+    public AttachmentSteps() {
     }
 
     @Before
-    public void before() throws IOException {
+    public void before() {
         disableExtensions = System.getProperty("cukedoctor.disable-extensions");
         hideStepTime = System.getProperty("HIDE_STEP_TIME");
         renderedDocument = null;
@@ -37,7 +36,7 @@ public class AttachmentSteps {
     }
 
     @After
-    public void after() throws IOException {
+    public void after() {
         // Assumed defaults across the test suite
         // There is no "after all" hook in Cucumber-JVM, so somewhat wastefully they go here
         resetProperty("cukedoctor.disable-extensions", disableExtensions);

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/ConverterSteps.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/ConverterSteps.java
@@ -20,7 +20,7 @@ public class ConverterSteps {
     String documentation;
 
     @When("^I convert their json test output using cukedoctor converter$")
-    public void I_convert_their_json_output_report_using_cukedoctor_converter(String docstring) throws Throwable {
+    public void I_convert_their_json_output_report_using_cukedoctor_converter(String docstring) {
         URL featureFile = getClass().getResource("/com/github/cukedoctor/json-output/simple.json");
         assertThat(featureFile).isNotNull();
         List<Feature> features = FeatureParser.parse(featureFile.getPath());
@@ -30,7 +30,7 @@ public class ConverterSteps {
     }
 
     @Then("^I should have awesome living documentation$")
-    public void I_should_have_awesome_living_documentation(String expected) throws Throwable {
+    public void I_should_have_awesome_living_documentation(String expected) {
        //remove include cause its resolved by asciidoctor converter
        assertThat(documentation.replaceAll("\r","").replace("include::" +
                "" +Constants.home() + "cukedoctor-intro.adoc[leveloffset=+1]","")).

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/EnrichmentSteps.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/EnrichmentSteps.java
@@ -45,27 +45,27 @@ public class EnrichmentSteps {
     }
 
     @When("^I convert docstring enriched json output activated with a step comment using cukedoctor converter$")
-    public void I_convert_docstring_enriched_json_output_activated_with_a_step_comment_using_cukedoctor_converter() throws Throwable {
+    public void I_convert_docstring_enriched_json_output_activated_with_a_step_comment_using_cukedoctor_converter() {
         getFeatureFixture("/json-output/enrichment/table-and-source-step-comment.json");
     }
 
     @When("^I convert enriched docstring with asciidoc content type using cukedoctor converter$")
-    public void I_convert_enriched_docstring_with_content_type_using_cukedoctor_converter() throws Throwable {
+    public void I_convert_enriched_docstring_with_content_type_using_cukedoctor_converter() {
         getFeatureFixture("/json-output/enrichment/table-and-source-content-type.json");
     }
 
     @When("^I convert enriched docstring with asciidoc feature tag using cukedoctor converter$")
-    public void I_convert_docstring_enriched_json_output_activiated_with_a_feature_tag_using_cukedoctor_converter() throws Throwable {
+    public void I_convert_docstring_enriched_json_output_activiated_with_a_feature_tag_using_cukedoctor_converter() {
         getFeatureFixture("/json-output/enrichment/table-and-source-feature-tag.json");
     }
 
     @When("^I convert enriched docstring with asciidoc scenario tag using cukedoctor converter$")
-    public void I_convert_docstring_enriched_json_output_activiated_with_a_scenario_tag_using_cukedoctor_converter() throws Throwable {
+    public void I_convert_docstring_enriched_json_output_activiated_with_a_scenario_tag_using_cukedoctor_converter() {
         getFeatureFixture("/json-output/enrichment/table-and-source-scenario-tag.json");
     }
 
     @When("^I convert enriched feature json output using cukedoctor$")
-    public void I_convert_enriched_feature_json_output_using_cukedoctor() throws Throwable {
+    public void I_convert_enriched_feature_json_output_using_cukedoctor() {
         getFeatureFixture("/json-output/enrichment/calc.json");
     }
 
@@ -78,7 +78,7 @@ public class EnrichmentSteps {
 
     @Then("^DocString asciidoc output must be rendered in my documentation$")
     @Then("^it should be rendered in AsciiDoc as$")
-    public void DocString_asciidoc_output_must_be_rendered_in_my_documentation(String expected) throws Throwable {
+    public void DocString_asciidoc_output_must_be_rendered_in_my_documentation(String expected) {
     	assertThat(documentation.replaceAll("\r","")).contains((expected.replaceAll("\r","")));
     }
 

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/IntroChapterSteps.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/IntroChapterSteps.java
@@ -20,9 +20,9 @@ public class IntroChapterSteps {
     String documentation;
 
     String introChapterContent;
-    
+
     @And("^The following asciidoc document is on your application classpath$")
-    public void I_convert_their_json_output_report_using_cukedoctor_converter(String docstring) throws Throwable {
+    public void I_convert_their_json_output_report_using_cukedoctor_converter(String docstring) {
         introChapterContent = docstring;
         URL featureFile = getClass().getResource("/com/github/cukedoctor/json-output/simple.json");
         assertThat(featureFile).isNotNull();
@@ -31,14 +31,14 @@ public class IntroChapterSteps {
         documentation = Cukedoctor.instance(features).renderDocumentation();
 
     }
-    
+
     @When("^Bdd tests results are converted into documentation by Cukedoctor$")
     public void Bdd_tests_results_are_converted_into_documentation_by_Cukedoctor(){
-        
+
     }
 
     @Then("^Resulting documentation should have the provided introduction chapter$")
-    public void I_should_have_awesome_living_documentation(String expected) throws Throwable {
+    public void I_should_have_awesome_living_documentation(String expected) {
 
        assertThat(documentation.replace("include::"+Constants.home()+"cukedoctor-intro.adoc[leveloffset=+1]",
            //need to add a '=' because of leveloffset intro chapter have

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/OrderingSteps.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/OrderingSteps.java
@@ -24,12 +24,12 @@ public class OrderingSteps {
 
 
     @Given("^The following two features:$")
-    public void the_following_two_features(String features) throws Throwable {
+    public void the_following_two_features(String features) {
         assertThat(features).isNotNull();
     }
 
     @When("^I convert them using default order$")
-    public void I_convert_the_using_default_order() throws Throwable {
+    public void I_convert_the_using_default_order() {
         URL featureFile = getClass().getResource("/com/github/cukedoctor/json-output/non-ordered.json");
         assertThat(featureFile).isNotNull();
         List<Feature> features = FeatureParser.parse(featureFile.getPath());
@@ -38,27 +38,27 @@ public class OrderingSteps {
     }
 
     @Then("^Features should be ordered by name in resulting documentation$")
-    public void Features_should_be_ordered_by_name_in_resulting_documentation(String expected) throws Throwable {
+    public void Features_should_be_ordered_by_name_in_resulting_documentation(String expected) {
         assertThat(documentation.replaceAll("\r", "")).isNotNull().contains(expected.replaceAll("\r", ""));
     }
 
     @When("^I convert them using comment order$")
-    public void I_convert_them__using_comment_order() throws Throwable {
+    public void I_convert_them__using_comment_order() {
         convert("/com/github/cukedoctor/json-output/ordered-comments.json");
     }
 
     @Then("^Features should be ordered respecting order comment$")
-    public void Features_should_be_ordered_respecting_order_comment(String expected) throws Throwable {
+    public void Features_should_be_ordered_respecting_order_comment(String expected) {
         assertFeaturesShouldBeOrdered(expected);
     }
 
     @When("^I convert them using tag order$")
-    public void I_convert_them__using_tag_order() throws Throwable {
+    public void I_convert_them__using_tag_order() {
         convert("/com/github/cukedoctor/json-output/ordered-tags.json");
     }
 
     @Then("^Features should be ordered respecting order tag$")
-    public void Features_should_be_ordered_respecting_order_tag(String expected) throws Throwable {
+    public void Features_should_be_ordered_respecting_order_tag(String expected) {
         assertFeaturesShouldBeOrdered(expected);
     }
 

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/TagRenderingSteps.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/cukedoctor/TagRenderingSteps.java
@@ -18,7 +18,7 @@ public class TagRenderingSteps {
     String documentation;
 
     @When("^I render the feature$")
-    public void I_render_the_feature() throws Throwable {
+    public void I_render_the_feature() {
         URL featureFile = getClass().getResource("/com/github/cukedoctor/json-output/tag-rendering.json");
         assertThat(featureFile).isNotNull();
         List<Feature> features = FeatureParser.parse(featureFile.getPath());

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/sample/BackgroundSteps.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/sample/BackgroundSteps.java
@@ -9,14 +9,14 @@ import io.cucumber.java.en.Given;
 public class BackgroundSteps {
 
   @Given("^this is a background step$")
-  public void this_is_a_background_step() throws Throwable {
+  public void this_is_a_background_step() {
   }
 
   @Given("^this is scenario one step$")
-  public void this_is_scenario_one_step() throws Throwable {
+  public void this_is_scenario_one_step() {
   }
 
   @Given("^this is scenario two step$")
-  public void this_is_scenario_two_step() throws Throwable {
+  public void this_is_scenario_two_step() {
   }
 }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/sample/CalcSteps.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/sample/CalcSteps.java
@@ -14,24 +14,24 @@ public class CalcSteps {
     int y;
 
     @Given("^I have numbers (\\d+) and (\\d+)$")
-    public void I_have_numbers_and(int x, int y, String asciidocString) throws Throwable {
+    public void I_have_numbers_and(int x, int y, String asciidocString) {
         this.x = x;
         this.y = y;
     }
 
 
     @When("^I sum the numbers using the following java code:$")
-    public void I_sum_the_numbers_using_the_following_java_code(String asciidocString) throws Throwable {
+    public void I_sum_the_numbers_using_the_following_java_code(String asciidocString) {
         result = x + y;
     }
 
     @When("^I sum the numbers$")
-    public void I_sum_the_numbers() throws Throwable {
+    public void I_sum_the_numbers() {
 
     }
 
     @Then("^I should have (\\d+) as result$")
-    public void I_should_have_as_result(int arg1, String asciidoc) throws Throwable {
+    public void I_should_have_as_result(int arg1, String asciidoc) {
         assertEquals(arg1,result);
     }
 }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/sample/DiscreteSteps.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/sample/DiscreteSteps.java
@@ -10,13 +10,13 @@ import static org.junit.Assert.assertNotNull;
 public class DiscreteSteps {
 
   @Given("^the following source code$")
-  public void the_following_source_code(String code) throws Throwable {
+  public void the_following_source_code(String code) {
     //it is just a sample, we are interested in json output report
     assertNotNull(code);
   }
 
   @Given("^the following table$")
-  public void the_following_table(String table) throws Throwable {
+  public void the_following_table(String table) {
     assertNotNull(table);
   }
 }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/sample/EnrichmentSteps.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/sample/EnrichmentSteps.java
@@ -11,12 +11,12 @@ import static org.junit.Assert.assertTrue;
 public class EnrichmentSteps {
 
     @Given("^I have listing in step docstring.$")
-    public void I_have_listing_in_feature_comments(String asciidoc) throws Throwable {
+    public void I_have_listing_in_feature_comments(String asciidoc) {
        assertTrue(true);
     }
 
     @Given("^I have admonition with a listing in step docstring.$")
-    public void I_have_admonition_with_a_listing_in_feature_comments(String asciidoc) throws Throwable {
+    public void I_have_admonition_with_a_listing_in_feature_comments(String asciidoc) {
         assertThat(Boolean.TRUE).isEqualTo(true);
     }
 

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/sample/SimpleSteps.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/bdd/sample/SimpleSteps.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertTrue;
 public class SimpleSteps {
 
     @Given("^scenario step$")
-    public void scenario_step() throws Throwable {
+    public void scenario_step() {
         //it is just a sample, we are interested in json output report
         assertTrue(true);
     }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/converter/CukedoctorConverterTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/converter/CukedoctorConverterTest.java
@@ -49,7 +49,7 @@ public class CukedoctorConverterTest {
     public void shouldFailToCreateDocumentationWithoutFeatures() {
         String msg = null;
         try {
-            Cukedoctor.instance(new ArrayList<Feature>());
+            Cukedoctor.instance(new ArrayList<>());
         } catch (RuntimeException re) {
             msg = re.getMessage();
         }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/example/EatCukesSteps.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/example/EatCukesSteps.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 public class EatCukesSteps {
 
 
-	private Belly belly = new Belly();
+	private final Belly belly = new Belly();
 
 	@Given("^I have (\\d+) cukes$")
 	public void haveCukes(int cukes) {

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/i18n/I18nLoaderTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/i18n/I18nLoaderTest.java
@@ -20,30 +20,41 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(JUnit4.class)
 public class I18nLoaderTest {
 
-    private static List<Feature> englishFeatures;
     private static List<Feature> noLanguageFeatures;
+    private static List<Feature> englishFeatures;
     private static List<Feature> portugueseFeatures;
     private static List<Feature> spanishFeatures;
     private static List<Feature> frenchFeatures;
-
-
+    private static List<Feature> portugueseTagFeatures;
+    private static List<Feature> spanishTagFeatures;
+    private static List<Feature> frenchTagFeatures;
 
     @BeforeClass
     public static void loadFeatures() {
         String englishFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/english.json");
+        String noLanguageFeature = FileUtil.findJsonFile("target/test-classes/json-output/outline.json");
         String portugueseFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/portuguese.json");
         String spanishFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/spanish.json");
         String frenchFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/french.json");
-        String noLanguageFeature = FileUtil.findJsonFile("target/test-classes/json-output/outline.json");
+        String portugueseTagFeature = FileUtil.findJsonFile(
+                "target/test-classes/json-output/i18n/portuguese_with_tag.json");
+        String spanishTagFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/spanish_with_tag.json");
+        String frenchTagFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/french_with_tag.json");
         englishFeatures = FeatureParser.parse(englishFeature);
         portugueseFeatures = FeatureParser.parse(portugueseFeature);
         spanishFeatures = FeatureParser.parse(spanishFeature);
         frenchFeatures = FeatureParser.parse(frenchFeature);
+        portugueseTagFeatures = FeatureParser.parse(portugueseTagFeature);
+        spanishTagFeatures = FeatureParser.parse(spanishTagFeature);
+        frenchTagFeatures = FeatureParser.parse(frenchTagFeature);
         noLanguageFeatures = FeatureParser.parse(noLanguageFeature);
         assertNotNull(englishFeatures);
         assertNotNull(portugueseFeatures);
         assertNotNull(spanishFeatures);
         assertNotNull(frenchFeatures);
+        assertNotNull(portugueseTagFeatures);
+        assertNotNull(spanishTagFeatures);
+        assertNotNull(frenchTagFeatures);
         assertNotNull(noLanguageFeatures);
     }
 
@@ -69,6 +80,14 @@ public class I18nLoaderTest {
     }
 
     @Test
+    public void shouldLoadPortugueseBundleFromTag(){
+        I18nLoader i18nLoader = I18nLoader.newInstance(portugueseTagFeatures);
+        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Funcionalidades");
+        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumo");
+        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Passos");
+    }
+
+    @Test
     public void shouldLoadSpanishBundle(){
         I18nLoader i18nLoader = I18nLoader.newInstance(spanishFeatures);
         assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Características");
@@ -77,8 +96,24 @@ public class I18nLoaderTest {
     }
 
     @Test
+    public void shouldLoadSpanishBundleFromTag(){
+        I18nLoader i18nLoader = I18nLoader.newInstance(spanishTagFeatures);
+        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Características");
+        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumen");
+        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Pasos");
+    }
+
+    @Test
     public void shouldLoadFrenchBundle(){
         I18nLoader i18nLoader = I18nLoader.newInstance(frenchFeatures);
+        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Fonctionnalités");
+        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Sommaire");
+        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Étapes");
+    }
+
+    @Test
+    public void shouldLoadFrenchBundleFromTag(){
+        I18nLoader i18nLoader = I18nLoader.newInstance(frenchTagFeatures);
         assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Fonctionnalités");
         assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Sommaire");
         assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Étapes");

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/parser/FeatureParserTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/parser/FeatureParserTest.java
@@ -1,11 +1,9 @@
 package com.github.cukedoctor.parser;
 
-import static com.github.cukedoctor.util.Constants.newLine;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
@@ -15,12 +13,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.github.cukedoctor.Cukedoctor;
-import com.github.cukedoctor.api.CukedoctorConverter;
 import com.github.cukedoctor.api.model.Feature;
 import com.github.cukedoctor.api.model.Scenario;
 import com.github.cukedoctor.api.model.Step;
-import com.github.cukedoctor.util.Expectations;
 import com.github.cukedoctor.util.FileUtil;
 import com.github.cukedoctor.util.builder.FeatureBuilder;
 
@@ -33,14 +28,14 @@ public class FeatureParserTest {
 	final String onePassingOneFailing = "one_passing_one_failing.json";
 
 	@Test
-	public void shouldParseFeature() throws IOException {
+	public void shouldParseFeature() {
 		String path = FileUtil.findJsonFile("target/test-classes/json-output/" + onePassingOneFailing);
 		List<Feature> features = FeatureParser.parse(path);
 		assertThat(features).isNotNull().hasSize(1).contains(FeatureBuilder.instance().name("One passing scenario, one failing scenario").id("one-passing-scenario,-one-failing-scenario").build());
 	}
 
 	@Test
-	public void shouldParseFeatureUsingResourcePath() throws IOException {
+	public void shouldParseFeatureUsingResourcePath() {
 		URL featureFile = getClass().getResource("/json-output/" + onePassingOneFailing);
 		String path = FileUtil.findJsonFile(featureFile.getPath());
 		List<Feature> features = FeatureParser.parse(path);
@@ -48,14 +43,14 @@ public class FeatureParserTest {
 	}
 
 	@Test
-	public void shouldParseFeatureUsingLeadingSlash() throws IOException {
+	public void shouldParseFeatureUsingLeadingSlash() {
 		String path = FileUtil.findJsonFile("/target/test-classes/json-output/" + onePassingOneFailing);
 		List<Feature> features = FeatureParser.parse(path);
 		assertThat(features).isNotNull().hasSize(1).contains(FeatureBuilder.instance().name("One passing scenario, one failing scenario").id("one-passing-scenario,-one-failing-scenario").build());
 	}
 
 	@Test
-	public void shouldParseFeaturesInDir() throws IOException {
+	public void shouldParseFeaturesInDir() {
 		List<String> paths = FileUtil.findJsonFiles("target/test-classes/json-output/parser");
 		assertThat(paths).hasSize(6);
 		List<Feature> features = FeatureParser.parse(paths);
@@ -63,13 +58,13 @@ public class FeatureParserTest {
 	}
 
 	@Test
-	public void shouldParseAndFindFeaturesInDir() throws IOException {
+	public void shouldParseAndFindFeaturesInDir() {
 		List<Feature> features = FeatureParser.findAndParse("target/test-classes/json-output/parser");
 		assertThat(features).hasSize(4).contains(FeatureBuilder.instance().name("An embed data directly feature").id("an-embed-data-directly-feature").build());
 	}
 
 	@Test
-	public void shouldParseFeatureWithDocstring() throws IOException {
+	public void shouldParseFeatureWithDocstring() {
 		List<Feature> features = FeatureParser.parse("target/test-classes/json-output/parser/feature_with_docstring.json");
 		assertThat(features).hasSize(1).contains(FeatureBuilder.instance().name("An embed data directly feature").id("an-embed-data-directly-feature").build());
 		List<Scenario> scenarios = features.get(0).getScenarios();
@@ -92,7 +87,7 @@ public class FeatureParserTest {
 	}
 
 	@Test
-	public void shouldParseFeatureWithOutput() throws IOException {
+	public void shouldParseFeatureWithOutput() {
 		List<Feature> features = FeatureParser.parse("target/test-classes/json-output/parser/feature_with_output.json");
 		assertThat(features).hasSize(1);
 		List<Scenario> scenarios = features.get(0).getScenarios();
@@ -106,7 +101,7 @@ public class FeatureParserTest {
 	}
 
 	@Test
-	public void shouldParseFeatureWithAttachments() throws IOException {
+	public void shouldParseFeatureWithAttachments() {
 		List<Feature> features = FeatureParser.parse("target/test-classes/json-output/attachments.json");
 		assertThat(features).hasSize(1);
 		List<Scenario> scenarios = features.get(0).getScenarios();
@@ -139,19 +134,19 @@ public class FeatureParserTest {
 	}
 
 	@Test
-	public void shouldParseAndFindFeaturesInDirUsingLeadingSlash() throws IOException {
+	public void shouldParseAndFindFeaturesInDirUsingLeadingSlash() {
 		List<Feature> features = FeatureParser.findAndParse("/target/test-classes/json-output/parser");
 		assertThat(features).hasSize(4).contains(FeatureBuilder.instance().name("An embed data directly feature").id("an-embed-data-directly-feature").build());
 	}
 
 	@Test
-	public void shouldParseAndFindFeaturesInDirUsingAbsoluteath() throws IOException {
-		List<Feature> features = FeatureParser.findAndParse(Paths.get("").toAbsolutePath().toString() +"/target/test-classes/json-output/parser");
+	public void shouldParseAndFindFeaturesInDirUsingAbsolutePath() {
+		List<Feature> features = FeatureParser.findAndParse(Paths.get("").toAbsolutePath() + "/target/test-classes/json-output/parser");
 		assertThat(features).hasSize(4).contains(FeatureBuilder.instance().name("An embed data directly feature").id("an-embed-data-directly-feature").build());
 	}
 
 	@Test
-	public void shouldParseFeatureInAbsolutePath() throws IOException {
+	public void shouldParseFeatureInAbsolutePath() {
 		String absolutePath = Paths.get("").toAbsolutePath() + "/target/test-classes/json-output/" + onePassingOneFailing;
 		String path = FileUtil.findJsonFile(absolutePath);
 		assertThat(path).isNotNull();
@@ -184,7 +179,7 @@ public class FeatureParserTest {
 		List<Feature> features = FeatureParser.parse(filePath);
 		assertNull(features);
 	}
-	
+
 	@Test
     public void shouldParseFeatureWithCommentsInScenariosExamples() {
         List<Feature> features = FeatureParser.parse(getClass().getResource("/json-output/feature_with_comments_in_examples.json").getPath());

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/renderer/CukedoctorFeatureRendererTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/renderer/CukedoctorFeatureRendererTest.java
@@ -301,10 +301,7 @@ public class CukedoctorFeatureRendererTest {
         final Feature feature = FeatureBuilder.instance().aFeatureWithOneScenarioWithOnePassingStep();
         Scenario scenarioToSkip = ScenarioBuilder.instance().name("scenario to skip").tag(new Tag("@skipDocs")).
                 type(Type.scenario).build();
-        ;
         feature.getScenarios().add(scenarioToSkip);
-        List<Feature> features = new ArrayList<>();
-        features.add(feature);
 
         CukedoctorFeatureRenderer featureRenderer = new CukedoctorFeatureRenderer();
         String resultDoc = featureRenderer.renderFeatureScenarios(feature, new CukedoctorDocumentBuilderImpl().createNestedBuilder().createNestedBuilder());
@@ -323,8 +320,6 @@ public class CukedoctorFeatureRendererTest {
     @Test
     public void shouldRenderFeatureScenariosWithMultipleSteps() {
         final Feature feature = FeatureBuilder.instance().aFeatureWithMultipleScenariosAndSteps();
-        List<Feature> features = new ArrayList<>();
-        features.add(feature);
         CukedoctorFeatureRenderer featureRenderer = new CukedoctorFeatureRenderer();
         String resultDoc = featureRenderer.renderFeatureScenarios(feature, new CukedoctorDocumentBuilderImpl().createNestedBuilder().createNestedBuilder());
         assertThat(resultDoc.replaceAll("\r", "")).isEqualTo(("==== Scenario: scenario icon:thumbs-down[role=\"red\",title=\"Failed\"]" + newLine() +
@@ -376,8 +371,6 @@ public class CukedoctorFeatureRendererTest {
     public void shouldNotGenerateSectionIdForFeatureBlankName() {
         final Feature feature = FeatureBuilder.instance().aFeatureWithOneScenarioWithOnePassingStep();
         feature.setName("    ");
-        List<Feature> features = new ArrayList<>();
-        features.add(feature);
         CukedoctorFeatureRenderer featureRenderer = new CukedoctorFeatureRenderer();
         assertThat(featureRenderer.renderFeatureSectionId(feature)).isEqualTo("");
     }
@@ -386,8 +379,6 @@ public class CukedoctorFeatureRendererTest {
     public void shouldNotRenderSectionIdForFeatureWithNullName() {
         final Feature feature = FeatureBuilder.instance().aFeatureWithOneScenarioWithOnePassingStep();
         feature.setName(null);
-        List<Feature> features = new ArrayList<>();
-        features.add(feature);
         CukedoctorFeatureRenderer featureRenderer = new CukedoctorFeatureRenderer();
         assertThat(featureRenderer.renderFeatureSectionId(feature)).isEqualTo("");
     }
@@ -396,8 +387,6 @@ public class CukedoctorFeatureRendererTest {
     public void shouldRenderSectionIdForFeatureWithNameWithSpaces() {
         final Feature feature = FeatureBuilder.instance().aFeatureWithOneScenarioWithOnePassingStep();
         feature.setName("Feature name");
-        List<Feature> features = new ArrayList<>();
-        features.add(feature);
         CukedoctorFeatureRenderer featureRenderer = new CukedoctorFeatureRenderer();
         assertThat(featureRenderer.renderFeatureSectionId(feature)).isEqualTo("[[Feature-name, Feature name]]");
     }
@@ -406,8 +395,6 @@ public class CukedoctorFeatureRendererTest {
     public void shouldRenderSectionIdForFeatureWithNameWithSpacesAndComma() {
         final Feature feature = FeatureBuilder.instance().aFeatureWithOneScenarioWithOnePassingStep();
         feature.setName("Feature name, subname");
-        List<Feature> features = new ArrayList<>();
-        features.add(feature);
         CukedoctorFeatureRenderer featureRenderer = new CukedoctorFeatureRenderer();
         assertThat(featureRenderer.renderFeatureSectionId(feature)).isEqualTo("[[Feature-name-subname, Feature name, subname]]");
     }
@@ -416,8 +403,6 @@ public class CukedoctorFeatureRendererTest {
     public void shouldRenderFeatureSectionId() {
         final Feature feature = FeatureBuilder.instance().aFeatureWithOneScenarioWithOnePassingStep();
         feature.setName("Name");
-        List<Feature> features = new ArrayList<>();
-        features.add(feature);
         CukedoctorFeatureRenderer featureRenderer = new CukedoctorFeatureRenderer();
         assertThat(featureRenderer.renderFeatureSectionId(feature)).isEqualTo("[[Name, Name]]");
     }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/renderer/CukedoctorScenarioRendererTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/renderer/CukedoctorScenarioRendererTest.java
@@ -21,8 +21,6 @@ public class CukedoctorScenarioRendererTest {
     @Test
     public void shouldRenderFeatureStepsWithOneScenarioWithMultipleStep() {
         final Feature feature = FeatureBuilder.instance().aFeatureWithOneScenarioWithMultipleSteps();
-        List<Feature> features = new ArrayList<>();
-        features.add(feature);
         List<Step> steps = feature.getScenarios().get(0).getSteps();
         CukedoctorStepsRenderer stepsRenderer = new CukedoctorStepsRenderer();
         String resultDoc = stepsRenderer.renderSteps(steps, feature.getScenarios().get(0), feature);

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/renderer/CukedoctorStepsRendererTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/renderer/CukedoctorStepsRendererTest.java
@@ -21,9 +21,6 @@ public class CukedoctorStepsRendererTest {
     @Test
     public void shouldRenderFeatureStepsWithOnePassingStep() {
         final Feature feature = FeatureBuilder.instance().aFeatureWithOneScenarioWithOnePassingStep();
-        List<Feature> features = new ArrayList<>();
-        features.add(feature);
-
         StepsRenderer stepsRenderer = new CukedoctorStepsRenderer();
 
         List<Step> steps = feature.getScenarios().get(0).getSteps();
@@ -39,9 +36,6 @@ public class CukedoctorStepsRendererTest {
     @Test
     public void shouldRenderFeatureStepsWithOnePassingAndOneFailingStep() {
         final Feature feature = FeatureBuilder.instance().aFeatureWithOneScenarioWithOnePassingAndOneFailingStep();
-        List<Feature> features = new ArrayList<>();
-        features.add(feature);
-
         List<Step> steps = feature.getScenarios().get(0).getSteps();
         StepsRenderer stepsRenderer = new CukedoctorStepsRenderer();
 

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/util/FileUtilTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/util/FileUtilTest.java
@@ -6,9 +6,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Paths;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by pestano on 29/06/15.

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/util/MetaCuke.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/util/MetaCuke.java
@@ -9,7 +9,7 @@ import java.util.LinkedList;
 
 public class MetaCuke {
     private final LinkedList<File> featureFiles = new LinkedList<>();
-    private File featureDirectory;
+    private final File featureDirectory;
     private File reportFile;
 
     public MetaCuke() throws IOException {

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/util/ServiceLoaderUtilTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/util/ServiceLoaderUtilTest.java
@@ -2,7 +2,6 @@ package com.github.cukedoctor.util;
 
 import com.github.cukedoctor.api.DocumentAttributes;
 import com.github.cukedoctor.config.CukedoctorConfig;
-import com.github.cukedoctor.config.GlobalConfig;
 import com.github.cukedoctor.i18n.I18nLoader;
 import com.github.cukedoctor.renderer.BaseRenderer;
 import org.junit.Test;

--- a/cukedoctor-converter/src/test/resources/json-output/i18n/french_with_tag.json
+++ b/cukedoctor-converter/src/test/resources/json-output/i18n/french_with_tag.json
@@ -1,0 +1,64 @@
+[
+  {
+    "line": 2,
+    "elements": [
+      {
+        "start_timestamp": "2022-07-21T08:24:32.069Z",
+        "line": 11,
+        "name": "L'API Open API est disponible sur demande",
+        "description": "",
+        "id": "l-api-swagger-est-disponible;l-api-open-api-est-disponible-sur-demande",
+        "type": "scenario",
+        "keyword": "Scénario",
+        "steps": [
+          {
+            "result": {
+              "duration": 148430000,
+              "status": "passed"
+            },
+            "line": 12,
+            "name": "l'application est active",
+            "match": {
+              "location": "org.rdlopes.cukedoctor.features.steps.RestOperationsSteps.applicationIsUp()"
+            },
+            "keyword": "Etant donné que "
+          },
+          {
+            "result": {
+              "duration": 274399000,
+              "status": "passed"
+            },
+            "line": 13,
+            "name": "je demande à obtenir les spécifications de l'API",
+            "match": {
+              "location": "org.rdlopes.cukedoctor.features.steps.RestOperationsSteps.iRequestTheOpenAPISpecifications()"
+            },
+            "keyword": "Quand "
+          },
+          {
+            "result": {
+              "duration": 4886000,
+              "status": "passed"
+            },
+            "line": 14,
+            "name": "je reçois les spécifications",
+            "match": {
+              "location": "org.rdlopes.cukedoctor.features.steps.RestOperationsSteps.iReceiveTheSpecsForTheApplication()"
+            },
+            "keyword": "Alors "
+          }
+        ]
+      }
+    ],
+    "name": "L'API Swagger est disponible",
+    "description": "  [quote]\n  ====\n  En tant que développeur,\n  je veux pouvoir accéder aux spécifications de l'Open API\n  afin de comprendre comment interagir avec l'application\n  ====",
+    "id": "l-api-swagger-est-disponible",
+    "keyword": "Fonctionnalité",
+    "uri": "classpath:features/01_plateforme/01_documentation.feature",
+    "tags": [
+      {
+        "name": "@language-fr"
+      }
+    ]
+  }
+]

--- a/cukedoctor-converter/src/test/resources/json-output/i18n/portuguese_with_tag.json
+++ b/cukedoctor-converter/src/test/resources/json-output/i18n/portuguese_with_tag.json
@@ -1,0 +1,149 @@
+[
+  {
+    "line": 3,
+    "elements": [
+      {
+        "line": 8,
+        "name": "Generate documentation of a single file",
+        "description": "",
+        "id": "cukedoctor-main;generate-documentation-of-a-single-file",
+        "type": "scenario",
+        "keyword": "Cenário",
+        "steps": [
+          {
+            "result": {
+              "duration": 187536110,
+              "status": "passed"
+            },
+            "line": 9,
+            "name": "A Cucumber json execution file is are already generated",
+            "match": {
+              "location": "CukedoctorMainSteps.A_Cucumber_json_execution_file_is_are_already_generated()"
+            },
+            "keyword": "Dado "
+          },
+          {
+            "result": {
+              "duration": 17662354279,
+              "status": "passed"
+            },
+            "line": 10,
+            "name": "I execute CukedoctorMain with args \"-o target/test-classes/outputFile.adoc\" \"-p target/test-classes/json-output/one_passing_one_failing.json\" and \"-t Documentation\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "-o target/test-classes/outputFile.adoc",
+                  "offset": 36
+                },
+                {
+                  "val": "-p target/test-classes/json-output/one_passing_one_failing.json",
+                  "offset": 77
+                },
+                {
+                  "val": "-t Documentation",
+                  "offset": 147
+                }
+              ],
+              "location": "CukedoctorMainSteps.I_execute_CukedoctorMain_with_args_and(String,String,String)"
+            },
+            "keyword": "Quando "
+          },
+          {
+            "result": {
+              "duration": 2905877,
+              "error_message": "org.junit.ComparisonFailure: expected:\u003c...0|0|22+|010ms|\u003d\u003d\u003d\u003d\u003d*[Features]*[[One-passing-scena...\u003e but was:\u003c...0|0|22+|010ms|\u003d\u003d\u003d\u003d\u003d*[??title.features??]*[[One-passing-scena...\u003e\n\tat org.junit.Assert.assertEquals(Assert.java:115)\n\tat org.junit.Assert.assertEquals(Assert.java:144)\n\tat com.github.cukedoctor.bdd.CukedoctorMainSteps.A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(CukedoctorMainSteps.java:44)\n\tat ✽.Então A file named outputFile.adoc should be generated with the following content:(src/test/resources/features/cukedoctor_main.feature:11)\n",
+              "status": "failed"
+            },
+            "line": 11,
+            "name": "A file named outputFile.adoc should be generated with the following content:",
+            "match": {
+              "location": "CukedoctorMainSteps.A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(String)"
+            },
+            "keyword": "Então ",
+            "doc_string": {
+              "content_type": "",
+              "line": 12,
+              "value": " :toc: right\n:backend: html5\n:doctitle: Documentation\n:doctype: book\n:icons: font\n:sectanchors:\n:sectlink:\n:docinfo:\n:source-highlighter: highlightjs\n:toclevels: 3\n:hardbreaks:\n\n\u003d *Documentation*\n\n\u003d\u003d *Summary*\n[cols\u003d\"12*^m\", options\u003d\"header,footer\"]\n|\u003d\u003d\u003d\n3+|Scenarios 7+|Steps 2+|Features: 1\n\n|[green]#*Passed*#\n|[red]#*Failed*#\n|Total\n|[green]#*Passed*#\n|[red]#*Failed*#\n|[purple]#*Skipped*#\n|[maroon]#*Pending*#\n|[yellow]#*Undefined*#\n|[blue]#*Missing*#\n|Total\n|Duration\n|Status\n\n12+^|*\u003c\u003cOne-passing-scenario-one-failing-scenario\u003e\u003e*\n|1\n|1\n|2\n|1\n|1\n|0\n|0\n|0\n|0\n|2\n|010ms\n|[red]#*failed*#\n12+^|*Totals*\n|1|1|2|1|1|0|0|0|0|2 2+|010ms\n|\u003d\u003d\u003d\n\n\u003d\u003d *Features*\n\n[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing scenario]]\n\u003d\u003d\u003d *One passing scenario, one failing scenario*\n\nminmax::One-passing-scenario-one-failing-scenario[]\n\u003d\u003d\u003d\u003d Scenario: Passing\n[small]#tags: @a,@b#\n\n****\nGiven ::\nthis step passes icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(001ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario: Failing\n[small]#tags: @a,@c#\n\n****\nGiven ::\nthis step fails icon:thumbs-down[role\u003d\"red\",title\u003d\"Failed\"] [small right]#(008ms)#\n\nIMPORTANT:  (RuntimeError)\n./features/step_definitions/steps.rb:4:in /^this step fails$/\u0027\nfeatures/one_passing_one_failing.feature:10:in Given this step fails\u0027\n****"
+            }
+          }
+        ]
+      },
+      {
+        "line": 92,
+        "name": "Generate documentation using multiple files",
+        "description": "",
+        "id": "cukedoctor-main;generate-documentation-using-multiple-files",
+        "type": "scenario",
+        "keyword": "Cenário",
+        "steps": [
+          {
+            "result": {
+              "duration": 60580,
+              "status": "passed"
+            },
+            "line": 93,
+            "name": "Cucumber multiple json execution files are already generate",
+            "match": {
+              "location": "CukedoctorMainSteps.Cucumber_multiple_json_execution_files_are_already_generate()"
+            },
+            "keyword": "Dado "
+          },
+          {
+            "result": {
+              "duration": 1194378335,
+              "status": "passed"
+            },
+            "line": 94,
+            "name": "I execute CukedoctorMain with args \"-o target/test-classes/outputFile.adoc\" \"-p target/test-classes/json-output/\" and \"-t Documentation\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "-o target/test-classes/outputFile.adoc",
+                  "offset": 36
+                },
+                {
+                  "val": "-p target/test-classes/json-output/",
+                  "offset": 77
+                },
+                {
+                  "val": "-t Documentation",
+                  "offset": 119
+                }
+              ],
+              "location": "CukedoctorMainSteps.I_execute_CukedoctorMain_with_args_and(String,String,String)"
+            },
+            "keyword": "Quando "
+          },
+          {
+            "result": {
+              "duration": 1774892,
+              "error_message": "org.junit.ComparisonFailure: expected:\u003c...|92+|10s114ms|\u003d\u003d\u003d\u003d\u003d*[Features]*[[An-embed-data-dir...\u003e but was:\u003c...|92+|10s114ms|\u003d\u003d\u003d\u003d\u003d*[??title.features??]*[[An-embed-data-dir...\u003e\n\tat org.junit.Assert.assertEquals(Assert.java:115)\n\tat org.junit.Assert.assertEquals(Assert.java:144)\n\tat com.github.cukedoctor.bdd.CukedoctorMainSteps.A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(CukedoctorMainSteps.java:44)\n\tat ✽.Então A file named outputFile.adoc should be generated with the following content:(src/test/resources/features/cukedoctor_main.feature:95)\n",
+              "status": "failed"
+            },
+            "line": 95,
+            "name": "A file named outputFile.adoc should be generated with the following content:",
+            "match": {
+              "location": "CukedoctorMainSteps.A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(String)"
+            },
+            "keyword": "Então ",
+            "doc_string": {
+              "content_type": "",
+              "line": 96,
+              "value": " :toc: right\n:backend: html5\n:doctitle: Documentation\n:doctype: book\n:icons: font\n:sectanchors:\n:sectlink:\n:docinfo:\n:source-highlighter: highlightjs\n:toclevels: 3\n:hardbreaks:\n\n\u003d *Documentation*\n\n\u003d\u003d *Summary*\n[cols\u003d\"12*^m\", options\u003d\"header,footer\"]\n|\u003d\u003d\u003d\n3+|Scenarios 7+|Steps 2+|Features: 4\n\n|[green]#*Passed*#\n|[red]#*Failed*#\n|Total\n|[green]#*Passed*#\n|[red]#*Failed*#\n|[purple]#*Skipped*#\n|[maroon]#*Pending*#\n|[yellow]#*Undefined*#\n|[blue]#*Missing*#\n|Total\n|Duration\n|Status\n\n12+^|*\u003c\u003cAn-embed-data-directly-feature\u003e\u003e*\n|3\n|0\n|3\n|3\n|0\n|0\n|0\n|0\n|0\n|3\n|000ms\n|[green]#*passed*#\n\n12+^|*\u003c\u003cAn-outline-feature\u003e\u003e*\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|000ms\n|[green]#*passed*#\n\n12+^|*\u003c\u003cOne-passing-scenario-one-failing-scenario\u003e\u003e*\n|1\n|1\n|2\n|1\n|1\n|0\n|0\n|0\n|0\n|2\n|010ms\n|[red]#*failed*#\n\n12+^|*\u003c\u003cSample-test\u003e\u003e*\n|1\n|1\n|2\n|3\n|1\n|0\n|0\n|0\n|0\n|4\n|10s 104ms\n|[red]#*failed*#\n12+^|*Totals*\n|5|2|7|7|2|0|0|0|0|9 2+|10s 114ms\n|\u003d\u003d\u003d\n\n\u003d\u003d *Features*\n\n[[An-embed-data-directly-feature, An embed data directly feature]]\n\u003d\u003d\u003d *An embed data directly feature*\n\nminmax::An-embed-data-directly-feature[]\n\u003d\u003d\u003d\u003d Scenario: scenario 1\n****\nGiven ::\nI embed data directly icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(000ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario Outline: scenario 2\n****\nGiven ::\nI embed data directly icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(000ms)#\n****\n\n****\nGiven ::\nI embed data directly icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(000ms)#\n****\n\n[[An-outline-feature, An outline feature]]\n\u003d\u003d\u003d *An outline feature*\n\nminmax::An-outline-feature[]\n\u003d\u003d\u003d\u003d Scenario Outline: outline\n\n.examples1\n[cols\u003d\"1*\", options\u003d\"header\"]\n|\u003d\u003d\u003d\n|status\n|passes\n|fails\n|\u003d\u003d\u003d\n\n.examples2\n[cols\u003d\"1*\", options\u003d\"header\"]\n|\u003d\u003d\u003d\n|status\n|passes\n|\u003d\u003d\u003d\n\n[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing scenario]]\n\u003d\u003d\u003d *One passing scenario, one failing scenario*\n\nminmax::One-passing-scenario-one-failing-scenario[]\n\u003d\u003d\u003d\u003d Scenario: Passing\n[small]#tags: @a,@b#\n\n****\nGiven ::\nthis step passes icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(001ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario: Failing\n[small]#tags: @a,@c#\n\n****\nGiven ::\nthis step fails icon:thumbs-down[role\u003d\"red\",title\u003d\"Failed\"] [small right]#(008ms)#\n\nIMPORTANT:  (RuntimeError)\n./features/step_definitions/steps.rb:4:in /^this step fails$/\u0027\nfeatures/one_passing_one_failing.feature:10:in Given this step fails\u0027\n****\n\n[[Sample-test, Sample test]]\n\u003d\u003d\u003d *Sample test*\n\nminmax::Sample-test[]\n****\nAs a user  +\nI want to do something  +\nIn order to achieve another thing\n****\n\n\u003d\u003d\u003d\u003d Scenario Outline: Parsing scenarios with multiple examples\n\n.Example\n[cols\u003d\"2*\", options\u003d\"header\"]\n|\u003d\u003d\u003d\n|a\n|b\n|1\n|2\n|\u003d\u003d\u003d\n\n\u003d\u003d\u003d\u003d Scenario: Basic\n****\nGiven ::\nI navigate to the home page icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(044ms)#\nThen ::\nI see the text \u0027Home\u0027 icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(001ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario: Basic failure\n****\nGiven ::\nI navigate to the home page icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(040ms)#\nThen ::\nI see the text \u0027Hacienda\u0027 icon:thumbs-down[role\u003d\"red\",title\u003d\"Failed\"] [small right]#(10s 017ms)#\n\nIMPORTANT: expected to find text \"Hacienda\" in \"Home | Login Clinical Studies some engaging copy View Available Studies\" (RSpec::Expectations::ExpectationNotMetError)\n./features/step_definitions/study_admin_steps.rb:14:in `/^I see the text \u0027(.+)\u0027$/\u0027\nfeatures/test_outline.feature:15:in `Then I see the text \u0027Hacienda\u0027\u0027\n****"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "Cukedoctor Main",
+    "description": "As a user of CukedoctorMain\nI want to generate asciidoc files based on my cucumber test output\nSo that I can generate wonderful living documentation",
+    "id": "cukedoctor-main",
+    "keyword": "Funcionalidade",
+    "uri": "src/test/resources/features/cukedoctor_main.feature",
+    "tags": [
+      {
+        "name": "@language-pt"
+      }
+    ]
+  }
+]

--- a/cukedoctor-converter/src/test/resources/json-output/i18n/spanish_with_tag.json
+++ b/cukedoctor-converter/src/test/resources/json-output/i18n/spanish_with_tag.json
@@ -1,0 +1,147 @@
+[
+  {
+    "line": 3,
+    "elements": [
+      {
+        "line": 8,
+        "name": "Generate documentation of a single file",
+        "description": "",
+        "id": "cukedoctor-main;generate-documentation-of-a-single-file",
+        "type": "scenario",
+        "keyword": "Escenario",
+        "steps": [
+          {
+            "result": {
+              "duration": 139108176,
+              "status": "passed"
+            },
+            "line": 9,
+            "name": "A Cucumber json execution file is are already generated",
+            "match": {
+              "location": "CukedoctorMainSteps.A_Cucumber_json_execution_file_is_are_already_generated()"
+            },
+            "keyword": "Dado "
+          },
+          {
+            "result": {
+              "duration": 4658484718,
+              "status": "passed"
+            },
+            "line": 10,
+            "name": "I execute CukedoctorMain with args \"-o target/test-classes/outputFile.adoc\" \"-p target/test-classes/json-output/one_passing_one_failing.json\" and \"-t Documentation\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "-o target/test-classes/outputFile.adoc",
+                  "offset": 36
+                },
+                {
+                  "val": "-p target/test-classes/json-output/one_passing_one_failing.json",
+                  "offset": 77
+                },
+                {
+                  "val": "-t Documentation",
+                  "offset": 147
+                }
+              ],
+              "location": "CukedoctorMainSteps.I_execute_CukedoctorMain_with_args_and(String,String,String)"
+            },
+            "keyword": "Cuando "
+          },
+          {
+            "result": {
+              "duration": 2054294,
+              "status": "passed"
+            },
+            "line": 11,
+            "name": "A file named outputFile.adoc should be generated with the following content:",
+            "match": {
+              "location": "CukedoctorMainSteps.A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(String)"
+            },
+            "keyword": "Entonces ",
+            "doc_string": {
+              "content_type": "",
+              "line": 12,
+              "value": " :toc: right\n:backend: html5\n:doctitle: Documentation\n:doctype: book\n:icons: font\n:sectanchors:\n:sectlink:\n:docinfo:\n:source-highlighter: highlightjs\n:toclevels: 3\n:hardbreaks:\n\n\u003d *Documentation*\n\n\u003d\u003d *Summary*\n[cols\u003d\"12*^m\", options\u003d\"header,footer\"]\n|\u003d\u003d\u003d\n3+|Scenarios 7+|Steps 2+|Features: 1\n\n|[green]#*Passed*#\n|[red]#*Failed*#\n|Total\n|[green]#*Passed*#\n|[red]#*Failed*#\n|[purple]#*Skipped*#\n|[maroon]#*Pending*#\n|[yellow]#*Undefined*#\n|[blue]#*Missing*#\n|Total\n|Duration\n|Status\n\n12+^|*\u003c\u003cOne-passing-scenario-one-failing-scenario\u003e\u003e*\n|1\n|1\n|2\n|1\n|1\n|0\n|0\n|0\n|0\n|2\n|010ms\n|[red]#*failed*#\n12+^|*Totals*\n|1|1|2|1|1|0|0|0|0|2 2+|010ms\n|\u003d\u003d\u003d\n\n\u003d\u003d *Features*\n\n[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing scenario]]\n\u003d\u003d\u003d *One passing scenario, one failing scenario*\n\nminmax::One-passing-scenario-one-failing-scenario[]\n\u003d\u003d\u003d\u003d Scenario: Passing\n[small]#tags: @a,@b#\n\n****\nGiven ::\nthis step passes icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(001ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario: Failing\n[small]#tags: @a,@c#\n\n****\nGiven ::\nthis step fails icon:thumbs-down[role\u003d\"red\",title\u003d\"Failed\"] [small right]#(008ms)#\n\nIMPORTANT:  (RuntimeError)\n./features/step_definitions/steps.rb:4:in /^this step fails$/\u0027\nfeatures/one_passing_one_failing.feature:10:in Given this step fails\u0027\n****"
+            }
+          }
+        ]
+      },
+      {
+        "line": 92,
+        "name": "Generate documentation using multiple files",
+        "description": "",
+        "id": "cukedoctor-main;generate-documentation-using-multiple-files",
+        "type": "scenario",
+        "keyword": "Escenario",
+        "steps": [
+          {
+            "result": {
+              "duration": 34895,
+              "status": "passed"
+            },
+            "line": 93,
+            "name": "Cucumber multiple json execution files are already generate",
+            "match": {
+              "location": "CukedoctorMainSteps.Cucumber_multiple_json_execution_files_are_already_generate()"
+            },
+            "keyword": "Dado "
+          },
+          {
+            "result": {
+              "duration": 953666274,
+              "status": "passed"
+            },
+            "line": 94,
+            "name": "I execute CukedoctorMain with args \"-o target/test-classes/outputFile.adoc\" \"-p target/test-classes/json-output/\" and \"-t Documentation\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "-o target/test-classes/outputFile.adoc",
+                  "offset": 36
+                },
+                {
+                  "val": "-p target/test-classes/json-output/",
+                  "offset": 77
+                },
+                {
+                  "val": "-t Documentation",
+                  "offset": 119
+                }
+              ],
+              "location": "CukedoctorMainSteps.I_execute_CukedoctorMain_with_args_and(String,String,String)"
+            },
+            "keyword": "Cuando "
+          },
+          {
+            "result": {
+              "duration": 1723911,
+              "status": "passed"
+            },
+            "line": 95,
+            "name": "A file named outputFile.adoc should be generated with the following content:",
+            "match": {
+              "location": "CukedoctorMainSteps.A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(String)"
+            },
+            "keyword": "Entonces ",
+            "doc_string": {
+              "content_type": "",
+              "line": 96,
+              "value": " :toc: right\n:backend: html5\n:doctitle: Documentation\n:doctype: book\n:icons: font\n:sectanchors:\n:sectlink:\n:docinfo:\n:source-highlighter: highlightjs\n:toclevels: 3\n:hardbreaks:\n\n\u003d *Documentation*\n\n\u003d\u003d *Summary*\n[cols\u003d\"12*^m\", options\u003d\"header,footer\"]\n|\u003d\u003d\u003d\n3+|Scenarios 7+|Steps 2+|Features: 4\n\n|[green]#*Passed*#\n|[red]#*Failed*#\n|Total\n|[green]#*Passed*#\n|[red]#*Failed*#\n|[purple]#*Skipped*#\n|[maroon]#*Pending*#\n|[yellow]#*Undefined*#\n|[blue]#*Missing*#\n|Total\n|Duration\n|Status\n\n12+^|*\u003c\u003cAn-embed-data-directly-feature\u003e\u003e*\n|3\n|0\n|3\n|3\n|0\n|0\n|0\n|0\n|0\n|3\n|000ms\n|[green]#*passed*#\n\n12+^|*\u003c\u003cAn-outline-feature\u003e\u003e*\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|000ms\n|[green]#*passed*#\n\n12+^|*\u003c\u003cOne-passing-scenario-one-failing-scenario\u003e\u003e*\n|1\n|1\n|2\n|1\n|1\n|0\n|0\n|0\n|0\n|2\n|010ms\n|[red]#*failed*#\n\n12+^|*\u003c\u003cSample-test\u003e\u003e*\n|1\n|1\n|2\n|3\n|1\n|0\n|0\n|0\n|0\n|4\n|10s 104ms\n|[red]#*failed*#\n12+^|*Totals*\n|5|2|7|7|2|0|0|0|0|9 2+|10s 114ms\n|\u003d\u003d\u003d\n\n\u003d\u003d *Features*\n\n[[An-embed-data-directly-feature, An embed data directly feature]]\n\u003d\u003d\u003d *An embed data directly feature*\n\nminmax::An-embed-data-directly-feature[]\n\u003d\u003d\u003d\u003d Scenario: scenario 1\n****\nGiven ::\nI embed data directly icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(000ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario Outline: scenario 2\n****\nGiven ::\nI embed data directly icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(000ms)#\n****\n\n****\nGiven ::\nI embed data directly icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(000ms)#\n****\n\n[[An-outline-feature, An outline feature]]\n\u003d\u003d\u003d *An outline feature*\n\nminmax::An-outline-feature[]\n\u003d\u003d\u003d\u003d Scenario Outline: outline\n\n.examples1\n[cols\u003d\"1*\", options\u003d\"header\"]\n|\u003d\u003d\u003d\n|status\n|passes\n|fails\n|\u003d\u003d\u003d\n\n.examples2\n[cols\u003d\"1*\", options\u003d\"header\"]\n|\u003d\u003d\u003d\n|status\n|passes\n|\u003d\u003d\u003d\n\n[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing scenario]]\n\u003d\u003d\u003d *One passing scenario, one failing scenario*\n\nminmax::One-passing-scenario-one-failing-scenario[]\n\u003d\u003d\u003d\u003d Scenario: Passing\n[small]#tags: @a,@b#\n\n****\nGiven ::\nthis step passes icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(001ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario: Failing\n[small]#tags: @a,@c#\n\n****\nGiven ::\nthis step fails icon:thumbs-down[role\u003d\"red\",title\u003d\"Failed\"] [small right]#(008ms)#\n\nIMPORTANT:  (RuntimeError)\n./features/step_definitions/steps.rb:4:in /^this step fails$/\u0027\nfeatures/one_passing_one_failing.feature:10:in Given this step fails\u0027\n****\n\n[[Sample-test, Sample test]]\n\u003d\u003d\u003d *Sample test*\n\nminmax::Sample-test[]\n****\nAs a user  +\nI want to do something  +\nIn order to achieve another thing\n****\n\n\u003d\u003d\u003d\u003d Scenario Outline: Parsing scenarios with multiple examples\n\n.Example\n[cols\u003d\"2*\", options\u003d\"header\"]\n|\u003d\u003d\u003d\n|a\n|b\n|1\n|2\n|\u003d\u003d\u003d\n\n\u003d\u003d\u003d\u003d Scenario: Basic\n****\nGiven ::\nI navigate to the home page icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(044ms)#\nThen ::\nI see the text \u0027Home\u0027 icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(001ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario: Basic failure\n****\nGiven ::\nI navigate to the home page icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(040ms)#\nThen ::\nI see the text \u0027Hacienda\u0027 icon:thumbs-down[role\u003d\"red\",title\u003d\"Failed\"] [small right]#(10s 017ms)#\n\nIMPORTANT: expected to find text \"Hacienda\" in \"Home | Login Clinical Studies some engaging copy View Available Studies\" (RSpec::Expectations::ExpectationNotMetError)\n./features/step_definitions/study_admin_steps.rb:14:in `/^I see the text \u0027(.+)\u0027$/\u0027\nfeatures/test_outline.feature:15:in `Then I see the text \u0027Hacienda\u0027\u0027\n****"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "Cukedoctor Main",
+    "description": "As a user of CukedoctorMain\nI want to generate asciidoc files based on my cucumber test output\nSo that I can generate wonderful living documentation",
+    "id": "cukedoctor-main",
+    "keyword": "Característica",
+    "uri": "src/test/resources/features/cukedoctor_main.feature",
+    "tags": [
+      {
+        "name": "@language-es"
+      }
+    ]
+  }
+]

--- a/cukedoctor-extension/src/main/java/com/github/cukedoctor/extension/CukedoctorFooterExtension.java
+++ b/cukedoctor-extension/src/main/java/com/github/cukedoctor/extension/CukedoctorFooterExtension.java
@@ -21,7 +21,7 @@ public class CukedoctorFooterExtension extends Postprocessor {
     public String process(Document document, String output) {
         if (document.isBasebackend("html") && System.getProperty("cukedoctor.disable.footer") == null) {
             String stopWatch = System.getProperty("cukedoctor.stopwatch");
-            Double generationTimeInSeconds = new Double(0);
+            double generationTimeInSeconds = 0;
             String documentationDate = dateFormat.format(new Date());
             String cukedoctorVersion = "";
             try {
@@ -32,7 +32,7 @@ public class CukedoctorFooterExtension extends Postprocessor {
             }
 
             if (stopWatch != null && !"".equals(stopWatch)) {
-                long begin = 0;
+                long begin;
                 try {
                     begin = Long.parseLong(stopWatch);
                     generationTimeInSeconds = (System.currentTimeMillis() - begin) / 1000.0;
@@ -47,7 +47,7 @@ public class CukedoctorFooterExtension extends Postprocessor {
                     "</a>");
             contentElement.append(" - " + documentationDate);
             contentElement.append("<span style=\"float:right;font-size:11px\"> Execution time: " +
-                    +generationTimeInSeconds + " seconds</span>");
+                    generationTimeInSeconds + " seconds</span>");
             return doc.html();
         } else {
             return output;

--- a/cukedoctor-extension/src/main/java/com/github/cukedoctor/extension/CukedoctorScriptExtension.java
+++ b/cukedoctor-extension/src/main/java/com/github/cukedoctor/extension/CukedoctorScriptExtension.java
@@ -7,8 +7,6 @@ import org.asciidoctor.extension.Postprocessor;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 
-import java.util.Map;
-
 /**
  * Created by pestano on 20/07/15.
  * adds javascript functions to html documentation

--- a/cukedoctor-extension/src/main/java/com/github/cukedoctor/extension/CukedoctorThemeExtension.java
+++ b/cukedoctor-extension/src/main/java/com/github/cukedoctor/extension/CukedoctorThemeExtension.java
@@ -8,7 +8,6 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 
 import java.io.File;
-import java.util.Map;
 
 /**
  * Created by pestano on 20/07/15.
@@ -21,8 +20,8 @@ public class CukedoctorThemeExtension extends Postprocessor {
         if (document.isBasebackend("html") && System.getProperty(THEME_DISABLE_EXT_KEY) == null) {
             Object docDir = document.getAttributes().get("docdir");
             if (docDir != null && new File(docDir.toString()).exists()) {
-                File themeDir = new File(docDir.toString() + "/themes/");
-                boolean created = false;
+                File themeDir = new File(docDir + "/themes/");
+                boolean created;
                 created = themeDir.mkdir();
                 if (created) {
                     FileUtil.copyFile("/themes/asciidoctor.css", docDir + "/themes/asciidoctor.css");
@@ -38,7 +37,7 @@ public class CukedoctorThemeExtension extends Postprocessor {
             }
 
             org.jsoup.nodes.Document doc = Jsoup.parse(output, "UTF-8");
-            Object tocPosition = document.document().getAttributes().get("toc-position");
+            Object tocPosition = document.getDocument().getAttributes().get("toc-position");
             boolean isTocRight = tocPosition != null && tocPosition.toString().equalsIgnoreCase("right");
             Element contentElement = doc.getElementsByAttributeValue("id", "header").get(0);
             contentElement.before("<div name=\"themes\" id=\"themes\" style=\"" +

--- a/cukedoctor-extension/src/test/java/com/github/cukedoctor/extension/FilterExtensionTest.java
+++ b/cukedoctor-extension/src/test/java/com/github/cukedoctor/extension/FilterExtensionTest.java
@@ -1,8 +1,8 @@
 package com.github.cukedoctor.extension;
 
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
-import static com.github.cukedoctor.extension.CukedoctorExtensionRegistry.*;
 import org.asciidoctor.SafeMode;
 import org.junit.*;
 import org.junit.runner.RunWith;
@@ -10,9 +10,10 @@ import org.junit.runners.JUnit4;
 
 import java.io.File;
 
+import static com.github.cukedoctor.extension.CukedoctorExtensionRegistry.FILTER_DISABLE_EXT_KEY;
 import static com.github.cukedoctor.extension.util.FileUtil.loadTestFile;
 import static com.github.cukedoctor.extension.util.FileUtil.readFileContent;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by pestano on 16/08/15.
@@ -23,18 +24,18 @@ public class FilterExtensionTest {
     private static Asciidoctor asciidoctor;
 
     @BeforeClass
-    public static void init(){
+    public static void init() {
         asciidoctor = Asciidoctor.Factory.create();
     }
 
 
     @AfterClass
-    public static void shutdown(){
-        if(asciidoctor != null){
+    public static void shutdown() {
+        if (asciidoctor != null) {
             asciidoctor.shutdown();
         }
         File file = loadTestFile("sample.html");
-        if(file.exists()){
+        if (file.exists()) {
             file.delete();
         }
 
@@ -42,32 +43,32 @@ public class FilterExtensionTest {
 
     @Before
     @After
-    public void enableExtension(){
+    public void enableExtension() {
         System.clearProperty(FILTER_DISABLE_EXT_KEY);
     }
 
     @Test
-    public void shouldAddSearchInputToRenderedHtml(){
+    public void shouldAddSearchInputToRenderedHtml() {
         File sampleAdoc = loadTestFile("sample.adoc");
         assertThat(sampleAdoc).exists();
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertThat(sampleHtml).isNotEmpty().
-                containsOnlyOnce("<input value=\"Filter...\"");
+                              containsOnlyOnce("<input value=\"Filter...\"");
 
     }
 
     @Test
-    public void shouldNotAddFilterToRenderedHtmlWhenExtensionDisabled(){
-        System.setProperty(FILTER_DISABLE_EXT_KEY,"anyValue");
+    public void shouldNotAddFilterToRenderedHtmlWhenExtensionDisabled() {
+        System.setProperty(FILTER_DISABLE_EXT_KEY, "anyValue");
         File sampleAdoc = loadTestFile("sample.adoc");
         assertThat(sampleAdoc).exists();
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertThat(sampleHtml).isNotEmpty().
-            doesNotContain("<input value=\"Filter...\"");
+                              doesNotContain("<input value=\"Filter...\"");
     }
 
 }

--- a/cukedoctor-extension/src/test/java/com/github/cukedoctor/extension/FooterExtensionTest.java
+++ b/cukedoctor-extension/src/test/java/com/github/cukedoctor/extension/FooterExtensionTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import static com.github.cukedoctor.extension.CukedoctorExtensionRegistry.*;
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 import org.junit.*;
@@ -49,7 +50,7 @@ public class FooterExtensionTest {
         File sampleAdoc = loadTestFile("sample.adoc");
         assertThat(sampleAdoc).exists();
         System.setProperty("cukedoctor.stopwatch",String.valueOf(System.currentTimeMillis()));
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertThat(sampleHtml.replaceAll("\n","").replace("\t","")).isNotEmpty().
@@ -64,7 +65,7 @@ public class FooterExtensionTest {
         File sampleAdoc = loadTestFile("sample.adoc");
         assertThat(sampleAdoc).exists();
         System.setProperty("cukedoctor.stopwatch",String.valueOf(System.currentTimeMillis()));
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertThat(sampleHtml.replaceAll("\n","").replace("\t","")).isNotEmpty().

--- a/cukedoctor-extension/src/test/java/com/github/cukedoctor/extension/MinMaxExtensionTest.java
+++ b/cukedoctor-extension/src/test/java/com/github/cukedoctor/extension/MinMaxExtensionTest.java
@@ -1,6 +1,7 @@
 package com.github.cukedoctor.extension;
 import static com.github.cukedoctor.extension.CukedoctorExtensionRegistry.*;
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 import org.junit.*;
@@ -49,7 +50,7 @@ public class MinMaxExtensionTest {
     public void shouldAddSearchInputToRenderedHtml(){
         File sampleAdoc = loadTestFile("sample.adoc");
         assertThat(sampleAdoc).exists();
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertNotNull(sampleHtml);
@@ -65,7 +66,7 @@ public class MinMaxExtensionTest {
         System.setProperty(MINMAX_DISABLE_EXT_KEY,"anyValue");
         File sampleAdoc = loadTestFile("sample.adoc");
         assertThat(sampleAdoc).exists();
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertNotNull(sampleHtml);

--- a/cukedoctor-extension/src/test/java/com/github/cukedoctor/extension/ScriptsExtensionTest.java
+++ b/cukedoctor-extension/src/test/java/com/github/cukedoctor/extension/ScriptsExtensionTest.java
@@ -1,6 +1,7 @@
 package com.github.cukedoctor.extension;
 import static com.github.cukedoctor.extension.CukedoctorExtensionRegistry.*;
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 import org.junit.*;
@@ -49,7 +50,7 @@ public class ScriptsExtensionTest {
     public void shouldAddScriptsToRenderedHtml(){
         File sampleAdoc = loadTestFile("sample.adoc");
         assertThat(sampleAdoc).exists();
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertThat(sampleHtml).isNotEmpty().
@@ -65,7 +66,7 @@ public class ScriptsExtensionTest {
         System.setProperty(THEME_DISABLE_EXT_KEY,"anyValue");
         File sampleAdoc = loadTestFile("sample.adoc");
         assertThat(sampleAdoc).exists();
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertThat(sampleHtml).isNotEmpty().
@@ -79,7 +80,7 @@ public class ScriptsExtensionTest {
         System.setProperty(FILTER_DISABLE_EXT_KEY,"anything");
         File sampleAdoc = loadTestFile("sample.adoc");
         assertThat(sampleAdoc).exists();
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertThat(sampleHtml).isNotEmpty().
@@ -93,7 +94,7 @@ public class ScriptsExtensionTest {
         System.setProperty(MINMAX_DISABLE_EXT_KEY,"any");
         File sampleAdoc = loadTestFile("sample.adoc");
         assertThat(sampleAdoc).exists();
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertThat(sampleHtml).isNotEmpty().

--- a/cukedoctor-extension/src/test/java/com/github/cukedoctor/extension/StyleExtensionTest.java
+++ b/cukedoctor-extension/src/test/java/com/github/cukedoctor/extension/StyleExtensionTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 
 import com.github.cukedoctor.extension.util.FileUtil;
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 import org.junit.*;
@@ -53,7 +54,7 @@ public class StyleExtensionTest {
         assertThat(sampleAdoc).exists();
         String customCssPath = Paths.get("").toAbsolutePath() + "/target/cukedoctor.css";
         FileUtil.copyFileFromClassPath("/cukedoctor-test.css", customCssPath);
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertThat(sampleHtml).isNotEmpty().
@@ -67,7 +68,7 @@ public class StyleExtensionTest {
         System.setProperty(STYLE_DISABLE_EXT_KEY,"anyValue");
         File sampleAdoc = loadTestFile("sample.adoc");
         assertThat(sampleAdoc).exists();
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertThat(sampleHtml).isNotEmpty().

--- a/cukedoctor-extension/src/test/java/com/github/cukedoctor/extension/ThemeExtensionTest.java
+++ b/cukedoctor-extension/src/test/java/com/github/cukedoctor/extension/ThemeExtensionTest.java
@@ -1,6 +1,7 @@
 package com.github.cukedoctor.extension;
 import static com.github.cukedoctor.extension.CukedoctorExtensionRegistry.*;
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 import org.junit.*;
@@ -48,7 +49,7 @@ public class ThemeExtensionTest {
         System.clearProperty(THEME_DISABLE_EXT_KEY);
         File sampleAdoc = loadTestFile("sample.adoc");
         assertThat(sampleAdoc).exists();
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertThat(sampleHtml).isNotEmpty().
@@ -61,7 +62,7 @@ public class ThemeExtensionTest {
         System.setProperty(THEME_DISABLE_EXT_KEY,"anyValue");
         File sampleAdoc = loadTestFile("sample.adoc");
         assertThat(sampleAdoc).exists();
-        asciidoctor.convertFile(sampleAdoc, OptionsBuilder.options().safe(SafeMode.UNSAFE).asMap());
+        asciidoctor.convertFile(sampleAdoc, Options.builder().safe(SafeMode.UNSAFE).build());
 
         String sampleHtml = readFileContent(loadTestFile("sample.html"));
         assertThat(sampleHtml).isNotEmpty().

--- a/cukedoctor-extension/src/test/resources/META-INF/services/com.github.cukedoctor.spi.SummaryRenderer
+++ b/cukedoctor-extension/src/test/resources/META-INF/services/com.github.cukedoctor.spi.SummaryRenderer
@@ -1,1 +1,0 @@
-com.github.cukedoctor.extension.spi.CustomSummaryRenderer

--- a/cukedoctor-main/pom.xml
+++ b/cukedoctor-main/pom.xml
@@ -34,12 +34,6 @@
             <artifactId>jcommander</artifactId>
             <version>1.48</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/cukedoctor-main/src/main/java/com/github/cukedoctor/CukedoctorMain.java
+++ b/cukedoctor-main/src/main/java/com/github/cukedoctor/CukedoctorMain.java
@@ -10,9 +10,7 @@ import com.github.cukedoctor.config.CukedoctorConfig;
 import com.github.cukedoctor.config.GlobalConfig;
 import com.github.cukedoctor.parser.FeatureParser;
 import com.github.cukedoctor.util.FileUtil;
-import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.OptionsBuilder;
-import org.asciidoctor.SafeMode;
+import org.asciidoctor.*;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -27,64 +25,64 @@ import static com.github.cukedoctor.util.Assert.hasText;
  */
 public class CukedoctorMain {
 
-    @Parameter(names = "-f", description = "Document format - supported html, pdf and all. Default is 'html'", required = false, echoInput = true)
+    @Parameter(names = "-f", description = "Document format - supported html, pdf and all. Default is 'html'", echoInput = true)
     private String format;
 
-    @Parameter(names = "-p", description = "Path to cucumber json output files (can be a directory or a file). Default is current directory", required = false)
+    @Parameter(names = "-p", description = "Path to cucumber json output files (can be a directory or a file). Default is current directory")
     private String path;
 
-    @Parameter(names = "-t", description = "Documentation title (first section). Default is 'Living Documentation'", required = false)
+    @Parameter(names = "-t", description = "Documentation title (first section). Default is 'Living Documentation'")
     private String title;
 
-    @Parameter(names = "-o", description = "File output name, can be a path eg: /home/doc which will result in doc.html|pdf in /home dir. Document title will be used if output name is not provided", required = false)
+    @Parameter(names = "-o", description = "File output name, can be a path eg: /home/doc which will result in doc.html|pdf in /home dir. Document title will be used if output name is not provided")
     private String outputName;
 
-    @Parameter(names = "-toc", description = "Table of contents position. Default is 'right' ", required = false)
+    @Parameter(names = "-toc", description = "Table of contents position. Default is 'right' ")
     private String toc;
 
-    @Parameter(names = "-numbered", description = "Section numbering. Default is false ", required = false)
-    private Boolean numbered = null;
+    @Parameter(names = "-numbered", description = "Section numbering. Default is false ")
+    private final Boolean numbered = null;
 
-    @Parameter(names = "-chapterLabel", description = "Chapter Label. Default is 'Chapter' ", required = false)
+    @Parameter(names = "-chapterLabel", description = "Chapter Label. Default is 'Chapter' ")
     private String chapterLabel;
 
-    @Parameter(names = "-versionLabel", description = "Version Label. Default is 'Version' ", required = false)
+    @Parameter(names = "-versionLabel", description = "Version Label. Default is 'Version' ")
     private String versionLabel;
 
-    @Parameter(names = "-hardbreaks", description = "Sets asciidoctor hardbreaks attribute. Default is true ", arity = 1, required = false)
+    @Parameter(names = "-hardbreaks", description = "Sets asciidoctor hardbreaks attribute. Default is true ", arity = 1)
     private Boolean hardBreaks;
 
-    @Parameter(names = "-docVersion", description = "Documentation version", required = false)
+    @Parameter(names = "-docVersion", description = "Documentation version")
     private String docVersion;
 
-    @Parameter(names = "-hideFeaturesSection", description = "Hides the 'features' section. Default is false ", required = false)
+    @Parameter(names = "-hideFeaturesSection", description = "Hides the 'features' section. Default is false ")
     private Boolean hideFeaturesSection;
 
-    @Parameter(names = "-hideSummarySection", description = "Hides the 'summary' section. Default is false ", required = false)
+    @Parameter(names = "-hideSummarySection", description = "Hides the 'summary' section. Default is false ")
     private Boolean hideSummarySection;
 
-    @Parameter(names = "-hideScenarioKeyword", description = "Hides the 'Scenario' keyword in scenario name. Default is false ", required = false)
+    @Parameter(names = "-hideScenarioKeyword", description = "Hides the 'Scenario' keyword in scenario name. Default is false ")
     private Boolean hideScenarioKeyword;
 
-    @Parameter(names = "-hideStepTime", description = "Does not render step time. Default is false ", required = false)
+    @Parameter(names = "-hideStepTime", description = "Does not render step time. Default is false ")
     private Boolean hideStepTime;
 
-    @Parameter(names = "-hideTags", description = "Does not render tags. Default is false ", required = false)
+    @Parameter(names = "-hideTags", description = "Does not render tags. Default is false ")
     private Boolean hideTags;
 
-    @Parameter(names = "-cucumberResultPaths", description = "Restricts the search to a list of paths, The list is obtained by splitting cucumberResultPaths using File.pathSeparator", required = false)
+    @Parameter(names = "-cucumberResultPaths", description = "Restricts the search to a list of paths, The list is obtained by splitting cucumberResultPaths using File.pathSeparator")
     private String cucumberResultPaths;
 
-    @Parameter(names = "-sourceHighlighter", description = "Configures source highlighter. Default is highlightjs", required = false)
+    @Parameter(names = "-sourceHighlighter", description = "Configures source highlighter. Default is highlightjs")
     private String sourceHighlighter;
 
-    @Parameter(names = "-allowUriRead", description = "Allow include content be referenced by an URI. Default is false", required = false)
+    @Parameter(names = "-allowUriRead", description = "Allow include content be referenced by an URI. Default is false")
     private Boolean allowUriRead;
 
-    @Parameter(names = "-stem", description = "Sets asciidoctor stem attribute with the specified interpreter. By default, the stem attribute is set using asciidoctor's default interpreter ", required = false)
+    @Parameter(names = "-stem", description = "Sets asciidoctor stem attribute with the specified interpreter. By default, the stem attribute is set using asciidoctor's default interpreter ")
     private String stem;
 
-    @Parameter(names = "-dataUri", description = "Sets AsciiDoc :data-uri: attribute, causing all images in the document to be embedded as data URIs. Default is false.", required = false)
+    @Parameter(names = "-dataUri", description = "Sets AsciiDoc :data-uri: attribute, causing all images in the document to be embedded as data URIs. Default is false.")
     private Boolean dataUri;
 
 
@@ -96,7 +94,7 @@ public class CukedoctorMain {
         }
     }
 
-    public String execute(String args[]) {
+    public String execute(String[] args) {
         JCommander commandLine = null;
         try {
             commandLine = new JCommander(this);
@@ -114,7 +112,7 @@ public class CukedoctorMain {
             outputName = title.replaceAll(" ", "-");
         }
 
-        if (format == null || (format.equals("html") && !format.equals("html5") && !format.equals("pdf") && !format.equals("all"))) {
+        if (format == null || format.equals("html")) {
             format = "html5";
         }
 
@@ -149,7 +147,7 @@ public class CukedoctorMain {
         System.out.println("-t" + ": " + title);
         System.out.println("-o" + ": " + outputName);
 
-        List<Feature> features = null;
+        List<Feature> features;
         if (cucumberResultPaths != null) {
             features = new ArrayList<>();
             String[] resultPaths = cucumberResultPaths.split(Pattern.quote(File.pathSeparator));
@@ -199,7 +197,7 @@ public class CukedoctorMain {
         }
         documentAttributes.docTitle(title);
 
-        String resultDoc = null;
+        String resultDoc;
         final CukedoctorConfig cukedoctorConfig = cukedoctorConfig();
         if ("all".equals(format)) {
             documentAttributes.backend("html5");
@@ -212,7 +210,7 @@ public class CukedoctorMain {
         return resultDoc;
     }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         CukedoctorMain main = new CukedoctorMain();
         main.execute(args);
     }
@@ -239,12 +237,14 @@ public class CukedoctorMain {
         if (documentAttributes.getBackend().equalsIgnoreCase("pdf")) {
             asciidoctor.unregisterAllExtensions();
         }
-        OptionsBuilder ob = OptionsBuilder.options()
-                .safe(SafeMode.UNSAFE)
-                .backend(documentAttributes.getBackend())
-                .attributes(documentAttributes.toMap());
+        AttributesBuilder attributesBuilder = Attributes.builder();
+        documentAttributes.toMap().forEach(attributesBuilder::attribute);
+        OptionsBuilder ob = Options.builder()
+                                   .safe(SafeMode.UNSAFE)
+                                   .backend(documentAttributes.getBackend())
+                                   .attributes(attributesBuilder.build());
         System.out.println("Document attributes\n" + documentAttributes.toMap());
-        asciidoctor.convertFile(adocFile, ob);
+        asciidoctor.convertFile(adocFile, ob.build());
         asciidoctor.shutdown();
         return doc;
     }

--- a/cukedoctor-main/src/test/java/com/github/cukedoctor/CukedoctorMainTest.java
+++ b/cukedoctor-main/src/test/java/com/github/cukedoctor/CukedoctorMainTest.java
@@ -151,7 +151,7 @@ public class CukedoctorMainTest {
     }
 
     @Test
-    public void shouldCreateDocumentationWithoutSummarySection() throws IOException {
+    public void shouldCreateDocumentationWithoutSummarySection() {
 
         try {
             new CukedoctorMain().execute(new String[]{
@@ -172,7 +172,7 @@ public class CukedoctorMainTest {
     }
 
     @Test
-    public void shouldCreateDocumentationWithoutScenarioKeyword() throws IOException {
+    public void shouldCreateDocumentationWithoutScenarioKeyword() {
         try {
             new CukedoctorMain().execute(new String[]{
                     "-hideScenarioKeyword", "",
@@ -193,7 +193,7 @@ public class CukedoctorMainTest {
     }
 
     @Test
-    public void shouldCreateDocumentationWithoutStepTime() throws IOException {
+    public void shouldCreateDocumentationWithoutStepTime() {
         try {
             new CukedoctorMain().execute(new String[]{
                     "-hideStepTime", "",
@@ -212,7 +212,7 @@ public class CukedoctorMainTest {
     }
 
     @Test
-    public void shouldCreateDocumentationUsingCoderaySourceHighlighter() throws IOException {
+    public void shouldCreateDocumentationUsingCoderaySourceHighlighter() {
         try {
             new CukedoctorMain().execute(new String[]{
                     "-hideStepTime", "",
@@ -233,7 +233,7 @@ public class CukedoctorMainTest {
 
 
     @Test
-    public void shouldCreateDocumentationWithoutTags() throws IOException {
+    public void shouldCreateDocumentationWithoutTags() {
         try {
             new CukedoctorMain().execute(new String[]{
                     "-hideTags", "",
@@ -304,7 +304,7 @@ public class CukedoctorMainTest {
     }
 
     @Test
-    public void shouldRestrictSearchPath() throws IOException {
+    public void shouldRestrictSearchPath() {
         CukedoctorMain main = new CukedoctorMain();
         System.out.flush();
         main.execute(new String[]{
@@ -323,7 +323,7 @@ public class CukedoctorMainTest {
     }
 
     @Test
-    public void shouldNotFindFeaturesByRestrictSearchPath() throws IOException {
+    public void shouldNotFindFeaturesByRestrictSearchPath() {
         CukedoctorMain main = new CukedoctorMain();
         System.out.flush();
         main.execute(new String[]{

--- a/cukedoctor-main/src/test/java/com/github/cukedoctor/bdd/CukedoctorMainSteps.java
+++ b/cukedoctor-main/src/test/java/com/github/cukedoctor/bdd/CukedoctorMainSteps.java
@@ -17,16 +17,16 @@ public class CukedoctorMainSteps {
 
 
 	@Given("^A Cucumber json execution file is are already generated$")
-	public void A_Cucumber_json_execution_file_is_are_already_generated() throws Throwable {
+	public void A_Cucumber_json_execution_file_is_are_already_generated() {
 	}
 
 	@Given("^Cucumber multiple json execution files are already generate$")
-	public void Cucumber_multiple_json_execution_files_are_already_generate() throws Throwable {
+	public void Cucumber_multiple_json_execution_files_are_already_generate() {
 	}
 
 
 	@When("^I execute CukedoctorMain with args \"([^\"]*)\" \"([^\"]*)\" and \"([^\"]*)\"$")
-	public void I_execute_CukedoctorMain_with_args_and(String arg1, String arg2, String arg3) throws Throwable {
+	public void I_execute_CukedoctorMain_with_args_and(String arg1, String arg2, String arg3) {
 		String[] args = new String[6];
 
 		args[0] = arg1.split(" ")[0];
@@ -40,7 +40,7 @@ public class CukedoctorMainSteps {
 	}
 
 	@Then("^A file named outputFile.adoc should be generated with the following content:$")
-	public void A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(final String fileContent) throws Throwable {
+	public void A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(final String fileContent) {
 	    assertEquals(fileContent.replaceAll(" ", "").replaceAll("\n", "").replaceAll("\r", "").replaceAll("\t", ""), generatedDoc.replaceAll("\r", "").replaceAll("\n", "").replaceAll("\t", "").replaceAll(" ",""));
 	}
 

--- a/cukedoctor-maven-plugin/pom.xml
+++ b/cukedoctor-maven-plugin/pom.xml
@@ -13,6 +13,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.cukedoctor</groupId>
             <artifactId>cukedoctor-converter</artifactId>
             <version>${project.parent.version}</version>

--- a/cukedoctor-maven-plugin/pom.xml
+++ b/cukedoctor-maven-plugin/pom.xml
@@ -43,12 +43,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
             <version>3.3.0</version>

--- a/cukedoctor-maven-plugin/src/main/java/com/github/cukedoctor/mojo/CukedoctorMojo.java
+++ b/cukedoctor-maven-plugin/src/main/java/com/github/cukedoctor/mojo/CukedoctorMojo.java
@@ -33,10 +33,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.Attributes;
-import org.asciidoctor.OptionsBuilder;
-import org.asciidoctor.SafeMode;
+import org.asciidoctor.*;
 import org.asciidoctor.extension.ExtensionGroup;
 
 import java.io.File;
@@ -49,82 +46,82 @@ import static com.github.cukedoctor.extension.CukedoctorExtensionRegistry.FILTER
         defaultPhase = LifecyclePhase.INSTALL)
 public class CukedoctorMojo extends AbstractMojo {
 
-    @Parameter(defaultValue = "documentation", required = false)
+    @Parameter(defaultValue = "documentation")
     String outputFileName;
 
-    @Parameter(defaultValue = "cukedoctor", required = false)
+    @Parameter(defaultValue = "cukedoctor")
     String outputDir;
 
-    @Parameter(required = false)
+    @Parameter()
     String featuresDir;
 
-    @Parameter(required = false)
+    @Parameter()
     String introChapterDir;
 
-    @Parameter(required = false)
+    @Parameter()
     String documentTitle;
 
     @Parameter(defaultValue = "html5", required = true)
     Format format;
 
-    @Parameter(defaultValue = "right", required = false)
+    @Parameter(defaultValue = "right")
     Toc toc;
 
-    @Parameter(defaultValue = "false", required = false)
+    @Parameter(defaultValue = "false")
     boolean numbered;
 
-    @Parameter(defaultValue = "false", required = false)
+    @Parameter(defaultValue = "false")
     boolean disableTheme;
 
-    @Parameter(defaultValue = "false", required = false)
+    @Parameter(defaultValue = "false")
     boolean disableFilter;
 
-    @Parameter(defaultValue = "false", required = false)
+    @Parameter(defaultValue = "false")
     boolean disableMinimizable;
 
-    @Parameter(defaultValue = "false", required = false)
+    @Parameter(defaultValue = "false")
     boolean disableFooter;
 
-    @Parameter(defaultValue = "Chapter", required = false)
+    @Parameter(defaultValue = "Chapter")
     String chapterLabel;
-    
-    @Parameter(defaultValue = "Version", required = false)
+
+    @Parameter(defaultValue = "Version")
     String versionLabel;
 
-    @Parameter(required = false)
+    @Parameter()
     String docVersion;
 
-    @Parameter(defaultValue = "true", required = false)
+    @Parameter(defaultValue = "true")
     boolean hardBreaks;
 
-    @Parameter(required = false)
+    @Parameter()
     Boolean hideFeaturesSection;
 
-    @Parameter(required = false)
+    @Parameter()
     Boolean hideSummarySection;
 
-    @Parameter(required = false)
+    @Parameter()
     Boolean hideScenarioKeyword;
 
-    @Parameter(required = false)
+    @Parameter()
     Boolean hideStepTime;
 
-    @Parameter(required = false)
+    @Parameter()
     Boolean hideTags;
 
-    @Parameter(required = false)
+    @Parameter()
     String sourceHighlighter;
 
-    @Parameter(required = false)
+    @Parameter()
     Boolean allowUriRead;
 
     @Parameter(property = "cukedoctor.skip", defaultValue = "false")
     private boolean skip;
 
-    @Parameter(property = "stem", required = false)
+    @Parameter(property = "stem")
     String stem;
 
-    @Parameter(property = "dataUri", required = false)
+    @Parameter(property = "dataUri")
     Boolean dataUri;
 
 
@@ -134,7 +131,7 @@ public class CukedoctorMojo extends AbstractMojo {
     private String generatedFile = null;//only for tests
 
 
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void execute() {
         if (skip) {
             getLog().info("Skipping cukedoctor-maven-plugin");
             return;
@@ -176,13 +173,13 @@ public class CukedoctorMojo extends AbstractMojo {
 
         getLog().info("Searching cucumber features in path: " + startDir);
         List<Feature> featuresFound = FeatureParser.findAndParse(startDir);
-        if (featuresFound == null || featuresFound.isEmpty()) {
+        if (featuresFound.isEmpty()) {
             getLog().warn("No cucumber json files found in " + startDir);
             return;
         } else {
             getLog().info("Generating living documentation for " + featuresFound.size() + " feature(s)...");
         }
-        
+
         if (chapterLabel == null) {
             chapterLabel = "Chapter";
         }
@@ -277,11 +274,12 @@ public class CukedoctorMojo extends AbstractMojo {
     }
 
     private void generateDocumentation(DocumentAttributes documentAttributes, File adocFile, Asciidoctor asciidoctor) {
-        
-        OptionsBuilder ob = OptionsBuilder.options()
+        AttributesBuilder attributesBuilder = Attributes.builder();
+        documentAttributes.toMap().forEach(attributesBuilder::attribute);
+        OptionsBuilder ob = Options.builder()
                 .safe(SafeMode.UNSAFE)
                 .backend(documentAttributes.getBackend())
-                .attributes(documentAttributes.toMap());
+                .attributes(attributesBuilder.build());
         getLog().info("Document attributes:\n"+documentAttributes.toMap());
         ExtensionGroup cukedoctorExtensionGroup = asciidoctor.createGroup(CUKEDOCTOR_EXTENSION_GROUP_NAME);
         if ("pdf".equals(documentAttributes.getBackend())) {
@@ -289,7 +287,7 @@ public class CukedoctorMojo extends AbstractMojo {
             //remove auxiliary files
             FileUtil.removeFile(adocFile.getParent() + "/" + outputFileName + "-theme.yml");
         }
-        asciidoctor.convertFile(adocFile, ob);
+        asciidoctor.convertFile(adocFile, ob.build());
 
         getLog().info("Generated documentation at: " + adocFile.getParent());
     }

--- a/cukedoctor-maven-plugin/src/main/java/com/github/cukedoctor/mojo/model/Format.java
+++ b/cukedoctor-maven-plugin/src/main/java/com/github/cukedoctor/mojo/model/Format.java
@@ -4,5 +4,5 @@ package com.github.cukedoctor.mojo.model;
  * Created by pestano on 28/06/15.
  */
 public enum Format {
-	html,html5, pdf, all;
+	html,html5, pdf, all
 }

--- a/cukedoctor-maven-plugin/src/main/java/com/github/cukedoctor/mojo/model/Toc.java
+++ b/cukedoctor-maven-plugin/src/main/java/com/github/cukedoctor/mojo/model/Toc.java
@@ -4,5 +4,5 @@ package com.github.cukedoctor.mojo.model;
  * Created by pestano on 28/06/15.
  */
 public enum Toc {
-	left,right,center;
+	left,right,center
 }

--- a/cukedoctor-maven-plugin/src/test/java/com/github/cukedoctor/mojo/FileUtil.java
+++ b/cukedoctor-maven-plugin/src/test/java/com/github/cukedoctor/mojo/FileUtil.java
@@ -1,6 +1,7 @@
 package com.github.cukedoctor.mojo;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 
 /**
@@ -12,22 +13,23 @@ public class FileUtil {
         StringBuilder content = new StringBuilder();
         try {
 
-            InputStream openStream = new FileInputStream(target);
+            InputStream openStream = Files.newInputStream(target.toPath());
             BufferedReader bufferedReader = new BufferedReader(
                     new InputStreamReader(openStream));
-            String line = null;
+            String line;
             while ((line = bufferedReader.readLine()) != null) {
                 content.append(line);
             }
             bufferedReader.close();
 
-        } catch (Exception e) {
+        } catch (Exception ignored) {
+            // noop
         }
         return content.toString();
     }
 
     public static File loadTestFile(String fileName) {
-        return new File(Paths.get("").toAbsolutePath().toString() + "/target/docs/" + fileName);
+        return new File(Paths.get("").toAbsolutePath() + "/target/docs/" + fileName);
     }
 
     public static String removeSpecialChars(String content) {

--- a/cukedoctor-multipage-layout/src/main/java/com/github/cukedoctor/multipage/defaults/DefaultMultipagePersister.java
+++ b/cukedoctor-multipage-layout/src/main/java/com/github/cukedoctor/multipage/defaults/DefaultMultipagePersister.java
@@ -18,8 +18,6 @@ import java.util.List;
 
 public class DefaultMultipagePersister implements MultipagePersister {
     private final static Logger logger = LoggerFactory.getLogger(DefaultMultipagePersister.class);
-    private DocumentAttributes documentAttributes;
-    private CukedoctorConfig cukedoctorConfig;
 
     @Override
     public void persist(MultipageDocumentation multipageDocumentation, File outputFolderLocation) {
@@ -43,7 +41,6 @@ public class DefaultMultipagePersister implements MultipagePersister {
 
     @Override
     public void setI18n(I18nLoader i18nProvider) {
-
     }
 
     @Override
@@ -53,11 +50,9 @@ public class DefaultMultipagePersister implements MultipagePersister {
 
     @Override
     public void setDocumentAttributes(DocumentAttributes documentAttributes) {
-        this.documentAttributes = documentAttributes;
     }
 
     @Override
     public void setCukedoctorConfig(CukedoctorConfig cukedoctorConfig) {
-        this.cukedoctorConfig = cukedoctorConfig;
     }
 }

--- a/cukedoctor-multipage-layout/src/main/java/com/github/cukedoctor/multipage/defaults/OnePagePerFeatureMultipagePager.java
+++ b/cukedoctor-multipage-layout/src/main/java/com/github/cukedoctor/multipage/defaults/OnePagePerFeatureMultipagePager.java
@@ -9,7 +9,6 @@ import com.github.cukedoctor.multipage.model.Page;
 import com.github.cukedoctor.multipage.spi.MultipagePager;
 import com.github.cukedoctor.parser.FeatureParser;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -22,7 +21,6 @@ import java.util.stream.Collectors;
  */
 public class OnePagePerFeatureMultipagePager implements MultipagePager {
     private DocumentAttributes documentAttributes;
-    private CukedoctorConfig cukedoctorConfig;
 
     @Override
     public List<Page> pages(List<String> jsonPaths) {
@@ -53,6 +51,5 @@ public class OnePagePerFeatureMultipagePager implements MultipagePager {
 
     @Override
     public void setCukedoctorConfig(CukedoctorConfig cukedoctorConfig) {
-        this.cukedoctorConfig = cukedoctorConfig;
     }
 }

--- a/cukedoctor-multipage-layout/src/test/java/com/github/cukedoctor/multipage/bdd/MultiPageLayoutSteps.java
+++ b/cukedoctor-multipage-layout/src/test/java/com/github/cukedoctor/multipage/bdd/MultiPageLayoutSteps.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue;
 public class MultiPageLayoutSteps {
     private String outputFolderLocation = "target/generated-sources/bdd";
     private final MetaCuke metaCuke = new MetaCuke();
-    private DocumentAttributes attrs = GlobalConfig.getInstance().getDocumentAttributes();
+    private final DocumentAttributes attrs = GlobalConfig.getInstance().getDocumentAttributes();
     private MultipageConverter multipageConverter;
 
     public MultiPageLayoutSteps() throws IOException {

--- a/cukedoctor-section-layout/src/main/java/com/github/cukedoctor/sectionlayout/SectionSummaryRenderer.java
+++ b/cukedoctor-section-layout/src/main/java/com/github/cukedoctor/sectionlayout/SectionSummaryRenderer.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 
 public class SectionSummaryRenderer extends AbstractBaseRenderer implements SummaryRenderer {
 
-    private final ServiceLoaderUtil<SummaryRenderer> loader;
     private Supplier<SummaryRenderer> renderer;
 
     public SectionSummaryRenderer() {
@@ -23,7 +22,6 @@ public class SectionSummaryRenderer extends AbstractBaseRenderer implements Summ
     }
 
     public SectionSummaryRenderer(ServiceLoaderUtil<SummaryRenderer> loader) {
-        this.loader = loader;
 
         renderer = () -> {
             SummaryRenderer val = loader.initialise(SummaryRenderer.class, CukedoctorSummaryRenderer.class, i18n, documentAttributes, cukedoctorConfig, SectionSummaryRenderer.class);

--- a/cukedoctor-section-layout/src/test/java/com/github/cukedoctor/sectionlayout/SectionSummaryRendererTest.java
+++ b/cukedoctor-section-layout/src/test/java/com/github/cukedoctor/sectionlayout/SectionSummaryRendererTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 @RunWith(JUnit4.class)
@@ -42,17 +41,19 @@ public class SectionSummaryRendererTest {
         final Feature eight = FeatureBuilder.instance().name("eight").keyword("Feature").tag("order-8").tag("@appendix").tag("@section-five").scenario(ScenarioBuilder.instance().name("Fake").build()).build();
 
         SummaryRenderer underlyingRenderer = mock(SummaryRenderer.class);
-        when(underlyingRenderer.renderSummary(any(List.class), any(CukedoctorDocumentBuilder.class))).thenReturn("My Summary");
+        when(underlyingRenderer.renderSummary(anyListOf(Feature.class), any(CukedoctorDocumentBuilder.class))).thenReturn(
+                "My Summary");
 
-        final SectionSummaryRenderer renderer = new SectionSummaryRenderer(new ServiceLoaderUtil<SummaryRenderer>(Collections.singletonList(underlyingRenderer)));
+        final SectionSummaryRenderer renderer = new SectionSummaryRenderer(new ServiceLoaderUtil<>(Collections.singletonList(
+                underlyingRenderer)));
 
         String result = renderer.renderSummary(Arrays.asList(six, five, three, four, one, two, seven, eight), CukedoctorDocumentBuilder.Factory.newInstance());
         assertEquals("My Summary", result);
 
         ArgumentCaptor<List> argumentCaptor = ArgumentCaptor.forClass(List.class);
-        verify(underlyingRenderer).renderSummary(argumentCaptor.<List<Feature>>capture(), any(CukedoctorDocumentBuilder.class));
+        verify(underlyingRenderer).renderSummary(argumentCaptor.capture(), any(CukedoctorDocumentBuilder.class));
 
-        List<Feature> features = argumentCaptor.<List<Feature>>getValue();
+        List<Feature> features = argumentCaptor.getValue();
         assertThat(features).containsExactly(one, two, three, four, five, six, seven, eight);
     }
 }

--- a/cukedoctor-spi-example/pom.xml
+++ b/cukedoctor-spi-example/pom.xml
@@ -10,13 +10,6 @@
     <artifactId>cukedoctor-spi-example</artifactId>
 
     <dependencies>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>com.github.cukedoctor</groupId>
             <artifactId>cukedoctor-converter</artifactId>

--- a/cukedoctor-spi-example/src/main/java/com/github/cukedoctor/example/spi/CustomFeatureRenderer.java
+++ b/cukedoctor-spi-example/src/main/java/com/github/cukedoctor/example/spi/CustomFeatureRenderer.java
@@ -12,46 +12,44 @@ import static com.github.cukedoctor.util.Constants.newLine;
 
 /**
  * Created by pestano on 29/02/16.
- *
- * renders features as labeled list: http://asciidoctor.org/docs/user-manual/#labeled-list
- *
+ * <p>
+ * renders features as <a href="http://asciidoctor.org/docs/user-manual/#labeled-list">labeled list</a>
+ * <p>
  * Template
- *
+ * <p>
  * Feature1::
  * +
  * ****
  * feature description
  * ****
- *   Scenario1:::
- *     +
- *     ****
- *      * Step1
- *      * Step2
- *      * StepN
- *     ****
- *   Scenario2:::
- *     +
- *     ****
- *      * Step1
- *      * Step2
- *     ****
- *
- *  Feature2:::
- *    //same as above
- *
+ * Scenario1:::
+ * +
+ * ****
+ * * Step1
+ * * Step2
+ * * StepN
+ * ****
+ * Scenario2:::
+ * +
+ * ****
+ * * Step1
+ * * Step2
+ * ****
+ * <p>
+ * Feature2:::
+ * //same as above
  */
 public class CustomFeatureRenderer extends CukedoctorFeatureRenderer {
-
 
     @Override
     public String renderFeature(Feature feature) {
         CukedoctorDocumentBuilder builder = docBuilder.createPeerBuilder();
-        builder.textLine((bold(feature.getName()))+"::").newLine();
+        builder.textLine((bold(feature.getName())) + "::").newLine();
         if (hasText(feature.getDescription())) {
             builder.append("+").sideBarBlock(feature.getDescription().trim().replaceAll("\\n", " +" + newLine()));
         }
 
-        if(feature.hasScenarios()){
+        if (feature.hasScenarios()) {
 
             ScenarioRenderer scenarioRenderer = new CustomScenarioRenderer();
             for (Scenario scenario : feature.getScenarios()) {

--- a/cukedoctor-spi-example/src/main/resources/META-INF/services/com.github.cukedoctor.spi.SummaryRenderer
+++ b/cukedoctor-spi-example/src/main/resources/META-INF/services/com.github.cukedoctor.spi.SummaryRenderer
@@ -1,3 +1,1 @@
 com.github.cukedoctor.example.spi.CustomSummaryRenderer
-com.github.cukedoctor.example.spi.CustomFeatureRenderer
-com.github.cukedoctor.example.spi.CustomScenarioRenderer

--- a/cukedoctor-spi-example/src/test/java/com/github/cukedoctor/example/bdd/CalcStepDef.java
+++ b/cukedoctor-spi-example/src/test/java/com/github/cukedoctor/example/bdd/CalcStepDef.java
@@ -15,23 +15,23 @@ public class CalcStepDef {
     int result;
 
     @Given("^I have numbers (\\d+) and (\\d+)$")
-    public void I_have_number_x_and_y(int x, int y, String docstring) throws Throwable {
+    public void I_have_number_x_and_y(int x, int y, String docstring) {
         this.x = x;
         this.y = y;
     }
 
     @When("^I sum the numbers$")
-    public void I_sum_the_number(String docstring) throws Throwable {
+    public void I_sum_the_number(String docstring) {
         result = x + y;
     }
 
     @When("^I subtract the numbers$")
-    public void I_subtract_the_number() throws Throwable {
+    public void I_subtract_the_number() {
         result = x - y;
     }
 
     @Then("^I should have (\\d+) as result$")
-    public void I_should_have_result(int result) throws Throwable {
+    public void I_should_have_result(int result) {
         assertEquals(result,this.result);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
                 <sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
                 <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
             </properties>
-            
+
             <build>
                 <plugins>
                     <plugin>
@@ -362,7 +362,7 @@
                         <version>3.4.0.905</version>
                     </plugin>
                 </plugins>
-            </build>    
+            </build>
         </profile>
 
     </profiles>


### PR DESCRIPTION
Hi Raphaël,
since I'm using Cucumber 7, I have been facing the disappearance of the language feature.

This, because Cucumber decided to stop supporting comments in JSON files.
So now, language comments are not anymore properly set in JSON features and the i18n is not working.

This change aims at adding a tag `@language-(en|es|fr|ge|pt)`, to mimic the behavior or ordering and allow users to update their Cucumber version.
