### PR TITLE
feat(converter): add a cukedoctor language tag @language-<language>

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,10 +29,10 @@ image:https://sonarcloud.io/api/project_badges/measure?project=com.github.cukedo
 
 BDD living documentation using http://cukes.info/[Cucumber] and http://asciidoctor.org[Asciidoctor] based on Cucumber http://www.relishapp.com/cucumber/cucumber/docs/formatters/json-output-formatter[JSON execution output].
 
- 
+
 [.text-right]
 https://goo.gl/Yp3NiU[Read this page in asciidoc for better reading experience]
-  
+
 
 == Narrative
 
@@ -188,6 +188,23 @@ Cukedoctor can use internationalization in two flavours:
 
 Cucumber feature languages are provided via comments in a feature file, https://github.com/cucumber/cucumber/wiki/Spoken-languages[see here^] for examples.
 
+Another way of setting the language is by using the `@language-<language>` tag:
+
+.i18n.feature.tag
+----
+@language-fr
+Fonctionnalité: Calculateur
+
+  Scénario: Addition de nombres
+
+----
+
+where `<language>` can be one of the supported locales, *en*, *es*, *fr*, *ge* and *pt*.
+
+WARNING: Please notice that the tag `@language-<language>` is not part of Cucumber.
+Meaning that you still need to setup Cucumber for i18n. the `@language-<language>` tag is part of Cukedoctor and serves as a
+convenient replacement for the `# language: <language>` comment, which is not supported anymore by Cucumber in JSON files.
+
 If your feature language is *not* supported by Cukedoctor you can https://github.com/rmpestano/cukedoctor/tree/master/cukedoctor-converter/src/main/resources/i18n[contribute it here^] or use a custom bundle.
 
 ==== Custom resource bundle
@@ -223,7 +240,7 @@ result.missing = Missing
 
 ==== Supported locales
 
-Cukdoctor currently supports the following locales *en*, *es*, *fr*, *ge* and *pt*.
+Cukedoctor currently supports the following locales *en*, *es*, *fr*, *ge* and *pt*.
 
 Here are the https://github.com/rmpestano/cukedoctor/tree/master/cukedoctor-converter/src/main/resources[supported locales^]
 
@@ -761,11 +778,11 @@ mvn cukedoctor:execute
 |false
 
 |featuresDir
-|Directory to start searching (recursively) for cucumber json output  
+|Directory to start searching (recursively) for cucumber json output
 |project root directory
 
 |disableFilter
-|When present, this flag disables features filtering 
+|When present, this flag disables features filtering
 |
 
 |disableMinimizable
@@ -1050,7 +1067,7 @@ docker run -v "$PWD:/output" rmpestano/cukedoctor -f pdf -o /output/generated_do
 
 It will search features (cucumber output in json format) in current folder (`$PWD`) and generate living documentation in  `/output/generated_doc`
 
-TIP: To change features folder just change first parameter of docker volume, ex: `docker run -v "/home:/output" ...` will search for cucumber features in `/home` directory.  
+TIP: To change features folder just change first parameter of docker volume, ex: `docker run -v "/home:/output" ...` will search for cucumber features in `/home` directory.
 
 NOTE: For Cukedoctor parameters details, see https://github.com/rmpestano/cukedoctor#usage-2[cukedoctor-cli^]
 

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Feature.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Feature.java
@@ -9,12 +9,7 @@ import com.github.cukedoctor.api.ScenarioResults;
 import com.github.cukedoctor.api.StepResults;
 import com.github.cukedoctor.util.Assert;
 import com.github.cukedoctor.util.Constants;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.slf4j.LoggerFactory;
@@ -35,19 +30,16 @@ public class Feature implements Comparable<Feature> {
   private StepResults stepResults;
   private ScenarioResults scenarioResults;
   private List<Comment> comments;
-  @JsonIgnore
-  private String language;
+  @JsonIgnore private String language;
 
-  @JsonIgnore
-  private Integer order;
+  @JsonIgnore private Integer order;
 
   @JsonIgnore
   private boolean
       backgroundRendered; // backgrounds runs for each scenario so we will render it only in the
   // first one
 
-  public Feature() {
-  }
+  public Feature() {}
 
   public String getId() {
     return id;

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Feature.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Feature.java
@@ -1,254 +1,261 @@
 package com.github.cukedoctor.api.model;
 
-import static com.github.cukedoctor.util.Assert.hasText;
-import static com.github.cukedoctor.util.Assert.notEmpty;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.github.cukedoctor.api.ScenarioResults;
 import com.github.cukedoctor.api.StepResults;
 import com.github.cukedoctor.util.Constants;
+
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
+import static com.github.cukedoctor.util.Assert.hasText;
+import static com.github.cukedoctor.util.Assert.notEmpty;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Feature implements Comparable<Feature> {
 
-  private String id;
-  private String name;
-  private String uri;
-  private String description;
-  private String keyword;
-  private List<Scenario> elements = new ArrayList<>();
-  private List<Scenario> scenarios = new ArrayList<>();
-  private List<Tag> tags = new ArrayList<>();
-  private StepResults stepResults;
-  private ScenarioResults scenarioResults;
-  private List<Comment> comments;
-  @JsonIgnore private String language;
+    private String id;
+    private String name;
+    private String uri;
+    private String description;
+    private String keyword;
+    private List<Scenario> elements = new ArrayList<>();
+    private List<Scenario> scenarios = new ArrayList<>();
+    private List<Tag> tags = new ArrayList<>();
+    private StepResults stepResults;
+    private ScenarioResults scenarioResults;
+    private List<Comment> comments;
+    @JsonIgnore
+    private String language;
 
-  @JsonIgnore private Integer order;
+    @JsonIgnore
+    private Integer order;
 
-  @JsonIgnore
-  private boolean
-      backgroundRendered; // backgrounds runs for each scenario so we will render it only in the
-  // first one
+    @JsonIgnore
+    private boolean backgroundRendered;//backgrounds runs for each scenario so we will render it only in the first one
 
-  public Feature() {}
 
-  public String getId() {
-    return id;
-  }
+    public Feature() {
 
-  public void setId(String id) {
-    this.id = id;
-  }
+    }
 
-  public String getUri() {
-    return this.uri;
-  }
+    public String getId() {
+        return id;
+    }
 
-  public void setUri(String uri) {
-    this.uri = uri;
-  }
+    public void setId(String id) {
+        this.id = id;
+    }
 
-  public boolean hasTags() {
-    return notEmpty(tags);
-  }
+    public String getUri() {
+        return this.uri;
+    }
 
-  public boolean hasScenarios() {
-    return !elements.isEmpty();
-  }
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
 
-  public Status getStatus() {
-    return notEmpty(scenarioResults.getFailedScenarios()) ? Status.failed : Status.passed;
-  }
+    public boolean hasTags() {
+        return notEmpty(tags);
+    }
 
-  public String getName() {
-    return name;
-  }
+    public boolean hasScenarios() {
+        return !elements.isEmpty();
+    }
 
-  public void setName(String name) {
-    this.name = name;
-  }
+    public Status getStatus() {
+        return notEmpty(scenarioResults.getFailedScenarios()) ? Status.failed : Status.passed;
+    }
 
-  public String getDescription() {
-    return description;
-  }
+    public String getName() {
+        return name;
+    }
 
-  public void setDescription(String description) {
-    this.description = description;
-  }
+    public void setName(String name) {
+        this.name = name;
+    }
 
-  public String getKeyword() {
-    return keyword;
-  }
+    public String getDescription() {
+        return description;
+    }
 
-  public void setKeyword(String keyword) {
-    this.keyword = keyword;
-  }
+    public void setDescription(String description) {
+        this.description = description;
+    }
 
-  public List<Scenario> getElements() {
-    return elements;
-  }
+    public String getKeyword() {
+        return keyword;
+    }
 
-  public void setElements(List<Scenario> elements) {
-    this.elements = elements;
-  }
+    public void setKeyword(String keyword) {
+        this.keyword = keyword;
+    }
 
-  public List<Tag> getTags() {
-    return tags;
-  }
+    public List<Scenario> getElements() {
+        return elements;
+    }
 
-  public void setTags(List<Tag> tags) {
-    this.tags = tags;
-  }
+    public void setElements(List<Scenario> elements) {
+        this.elements = elements;
+    }
 
-  public StepResults getStepResults() {
-    return stepResults;
-  }
+    public List<Tag> getTags() {
+        return tags;
+    }
 
-  public ScenarioResults getScenarioResults() {
-    return scenarioResults;
-  }
+    public void setTags(List<Tag> tags) {
+        this.tags = tags;
+    }
 
-  public List<Comment> getComments() {
-    return comments;
-  }
+    public StepResults getStepResults() {
+        return stepResults;
+    }
 
-  public void setComments(List<Comment> comments) {
-    this.comments = comments;
-  }
+    public ScenarioResults getScenarioResults() {
+        return scenarioResults;
+    }
 
-  public boolean isBackgroundRendered() {
-    return backgroundRendered;
-  }
+    public List<Comment> getComments() {
+        return comments;
+    }
 
-  public void setBackgroundRendered(boolean backgroundRendered) {
-    this.backgroundRendered = backgroundRendered;
-  }
+    public void setComments(List<Comment> comments) {
+        this.comments = comments;
+    }
 
-  /**
-   * @return total number of scenarios
-   * @deprecated use {@link Feature#getScenarioResults()}
-   */
-  @Deprecated
-  public Integer getNumberOfScenarios() {
-    Integer result = 0;
-    if (scenarios != null) {
-      List<Scenario> elementList = new ArrayList<Scenario>();
-      for (Scenario element : scenarios) {
-        if (!element.hasExamples()) {
-          elementList.add(element);
+
+    public boolean isBackgroundRendered() {
+        return backgroundRendered;
+    }
+
+
+    public void setBackgroundRendered(boolean backgroundRendered) {
+        this.backgroundRendered = backgroundRendered;
+    }
+
+
+    /**
+     * @return total number of scenarios
+     * @deprecated use {@link Feature#getScenarioResults()}
+     */
+    @Deprecated
+    public Integer getNumberOfScenarios() {
+        Integer result = 0;
+        if (scenarios != null) {
+            List<Scenario> elementList = new ArrayList<Scenario>();
+            for (Scenario element : scenarios) {
+                if (!element.hasExamples()) {
+                    elementList.add(element);
+                }
+            }
+            result = elementList.size();
         }
-      }
-      result = elementList.size();
+        return result;
     }
-    return result;
-  }
 
-  public Integer getNumberOfSteps() {
-    return stepResults.getNumberOfSteps();
-  }
-
-  public Integer getNumberOfPasses() {
-    return stepResults.getNumberOfPasses();
-  }
-
-  public Integer getNumberOfFailures() {
-    return stepResults.getNumberOfFailures();
-  }
-
-  public Integer getNumberOfPending() {
-    return stepResults.getNumberOfPending();
-  }
-
-  public Integer getNumberOfSkipped() {
-    return stepResults.getNumberOfSkipped();
-  }
-
-  public Integer getNumberOfMissing() {
-    return stepResults.getNumberOfMissing();
-  }
-
-  public Integer getNumberOfUndefined() {
-    return stepResults.getNumberOfUndefined();
-  }
-
-  public String getDurationOfSteps() {
-    return stepResults.getTotalDurationAsString();
-  }
-
-  public Integer getNumberOfScenariosPassed() {
-    return scenarioResults.getNumberOfScenariosPassed();
-  }
-
-  public Integer getNumberOfScenariosFailed() {
-    return scenarioResults.getNumberOfScenariosFailed();
-  }
-
-  public List<Scenario> getScenarios() {
-    return scenarios; // scenario & scenario outline
-  }
-
-  public void initScenarios() {
-    if (elements != null) {
-      for (Scenario element : elements) {
-        scenarios.add(element);
-      }
+    public Integer getNumberOfSteps() {
+        return stepResults.getNumberOfSteps();
     }
-  }
 
-  public void processSteps() {
-    if (!isCucumberFeature()) {
-      return;
+    public Integer getNumberOfPasses() {
+        return stepResults.getNumberOfPasses();
     }
-    List<Step> allSteps = new ArrayList<Step>();
-    Map<Status, AtomicInteger> statusCounter = new HashMap<>();
-    for (Status status : Status.values()) {
-      statusCounter.put(status, new AtomicInteger(0));
-    }
-    List<Scenario> passedScenarios = new ArrayList<Scenario>();
-    List<Scenario> failedScenarios = new ArrayList<Scenario>();
-    long totalDuration = 0L;
 
-    if (scenarios != null) {
-      for (Scenario scenario : scenarios) {
-        if (scenario.hasExamples()) {
-          continue;
+    public Integer getNumberOfFailures() {
+        return stepResults.getNumberOfFailures();
+    }
+
+    public Integer getNumberOfPending() {
+        return stepResults.getNumberOfPending();
+    }
+
+    public Integer getNumberOfSkipped() {
+        return stepResults.getNumberOfSkipped();
+    }
+
+    public Integer getNumberOfMissing() {
+        return stepResults.getNumberOfMissing();
+    }
+
+    public Integer getNumberOfUndefined() {
+        return stepResults.getNumberOfUndefined();
+    }
+
+    public String getDurationOfSteps() {
+        return stepResults.getTotalDurationAsString();
+    }
+
+    public Integer getNumberOfScenariosPassed() {
+        return scenarioResults.getNumberOfScenariosPassed();
+    }
+
+    public Integer getNumberOfScenariosFailed() {
+        return scenarioResults.getNumberOfScenariosFailed();
+    }
+
+    public List<Scenario> getScenarios() {
+        return scenarios;//scenario & scenario outline
+    }
+
+    public void initScenarios() {
+        if (elements != null) {
+            for (Scenario element : elements) {
+                scenarios.add(element);
+            }
         }
-        calculateScenarioStats(passedScenarios, failedScenarios, scenario);
-        if (scenario.hasSteps()) {
-          for (Step step : scenario.getSteps()) {
-            allSteps.add(step);
-            statusCounter.get(step.getStatus()).incrementAndGet();
-            totalDuration += step.getDuration();
-          }
+
+    }
+
+    public void processSteps() {
+        if (!isCucumberFeature()) {
+            return;
         }
-      }
-    }
-    scenarioResults = new ScenarioResults(passedScenarios, failedScenarios);
-    stepResults = new StepResults(allSteps, statusCounter, totalDuration);
-  }
+        List<Step> allSteps = new ArrayList<Step>();
+        Map<Status, AtomicInteger> statusCounter = new HashMap<>();
+        for (Status status : Status.values()) {
+            statusCounter.put(status, new AtomicInteger(0));
+        }
+        List<Scenario> passedScenarios = new ArrayList<Scenario>();
+        List<Scenario> failedScenarios = new ArrayList<Scenario>();
+        long totalDuration = 0L;
 
-  private void calculateScenarioStats(
-      List<Scenario> passedScenarios, List<Scenario> failedScenarios, Scenario element) {
-    if (element.isBackground()) {
-      return; // background scenarios are not considered as scenrario
+        if (scenarios != null) {
+            for (Scenario scenario : scenarios) {
+                if (scenario.hasExamples()) {
+                    continue;
+                }
+                calculateScenarioStats(passedScenarios, failedScenarios, scenario);
+                if (scenario.hasSteps()) {
+                    for (Step step : scenario.getSteps()) {
+                        allSteps.add(step);
+                        statusCounter.get(step.getStatus()).incrementAndGet();
+                        totalDuration += step.getDuration();
+                    }
+                }
+            }
+        }
+        scenarioResults = new ScenarioResults(passedScenarios, failedScenarios);
+        stepResults = new StepResults(allSteps, statusCounter, totalDuration);
     }
-    if (element.getStatus() == Status.passed) {
-      passedScenarios.add(element);
-    } else if (element.getStatus() == Status.failed) {
-      failedScenarios.add(element);
-    }
-  }
 
-  public boolean isCucumberFeature() {
-    return this.getName() != null
-        && this.getKeyword() != null
-        && (this.elements != null && !this.elements.isEmpty());
-  }
+    private void calculateScenarioStats(List<Scenario> passedScenarios, List<Scenario> failedScenarios, Scenario element) {
+        if (element.isBackground()) {
+            return;//background scenarios are not considered as scenrario
+        }
+        if (element.getStatus() == Status.passed) {
+            passedScenarios.add(element);
+        } else if (element.getStatus() == Status.failed) {
+            failedScenarios.add(element);
+        }
+    }
+
+
+    public boolean isCucumberFeature() {
+        return this.getName() != null && this.getKeyword() != null && (this.elements != null && !this.elements.isEmpty());
+    }
 
     public String getLanguage() {
         if (language == null && comments != null) {
@@ -267,28 +274,28 @@ public class Feature implements Comparable<Feature> {
             this.language = "";
         }
 
-    return language;
-  }
-
-  public int getOrder() {
-    if (order == null && comments != null) {
-      for (Comment comment : comments) {
-        trySetOrder(comment.getOrder(), "comment");
-      }
+        return language;
     }
 
-    if (order == null && hasTags()) {
-      for (Tag tag : getTags()) {
-        trySetOrder(tag.getOrder(), "tag");
-      }
-    }
+    public int getOrder() {
+        if (order == null && comments != null) {
+            for (Comment comment : comments) {
+                trySetOrder(comment.getOrder(), "comment");
+            }
+        }
 
-    if (order == null) {
-      this.order = Integer.MAX_VALUE;
-    }
+        if (order == null && hasTags()) {
+            for (Tag tag : getTags()) {
+                trySetOrder(tag.getOrder(), "tag");
+            }
+        }
 
-    return order;
-  }
+        if (order == null) {
+            this.order = Integer.MAX_VALUE;
+        }
+
+        return order;
+    }
 
     private void trySetOrder(Optional<String> order, String source) {
         if (order.isPresent() && hasText(order.get())) {
@@ -318,64 +325,66 @@ public class Feature implements Comparable<Feature> {
         }
     }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
-    Feature feature = (Feature) o;
+        Feature feature = (Feature) o;
 
-    return !(id != null ? !id.equals(feature.id) : feature.id != null);
-  }
+        return !(id != null ? !id.equals(feature.id) : feature.id != null);
 
-  @Override
-  public int hashCode() {
-    return name != null ? name.hashCode() : 42;
-  }
+    }
 
-  public boolean hasIgnoreDocsTag() {
-    if (hasTags()) {
-      for (Tag tag : tags) {
-        if (Constants.SKIP_DOCS.equalsIgnoreCase(tag.getName())) {
-          return true;
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 42;
+    }
+
+    public boolean hasIgnoreDocsTag() {
+        if (hasTags()) {
+            for (Tag tag : tags) {
+                if (Constants.SKIP_DOCS.equalsIgnoreCase(tag.getName())) {
+                    return true;
+                }
+            }
         }
-      }
-    }
-    return false;
-  }
-
-  @Override
-  public String toString() {
-    return name;
-  }
-
-  @Override
-  public int compareTo(Feature other) {
-    int result = Integer.compare(getOrder(), other.getOrder());
-
-    // same order or no-order use name
-    if (result == 0) {
-      result = name.compareTo(other.getName());
+        return false;
     }
 
-    return result;
-  }
+    @Override
+    public String toString() {
+        return name;
+    }
 
-  public Scenario getScenarioByName(String name) {
+    @Override
+    public int compareTo(Feature other) {
+        int result = Integer.compare(getOrder(), other.getOrder());
 
-    if (hasText(name) && hasScenarios()) {
-      for (Scenario scenario : scenarios) {
-        if (hasText(scenario.getName()) && scenario.getName().trim().equals(name)) {
-          return scenario;
+        //same order or no-order use name
+        if (result == 0) {
+            result = name.compareTo(other.getName());
         }
-      }
-    }
-    return null;
-  }
 
-  public boolean hasTag(String pattern) {
-    return extractTag(pattern).isPresent();
-  }
+        return result;
+
+    }
+
+    public Scenario getScenarioByName(String name) {
+
+        if (hasText(name) && hasScenarios()) {
+            for (Scenario scenario : scenarios) {
+                if (hasText(scenario.getName()) && scenario.getName().trim().equals(name)) {
+                    return scenario;
+                }
+            }
+        }
+        return null;
+    }
+
+    public boolean hasTag(String pattern) {
+        return extractTag(pattern).isPresent();
+    }
 
     public Optional<String> extractTag(String pattern) {
         if (!hasTags()) {

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Feature.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Feature.java
@@ -1,399 +1,389 @@
 package com.github.cukedoctor.api.model;
 
+import static com.github.cukedoctor.util.Assert.hasText;
+import static com.github.cukedoctor.util.Assert.notEmpty;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.github.cukedoctor.api.ScenarioResults;
 import com.github.cukedoctor.api.StepResults;
+import com.github.cukedoctor.util.Assert;
 import com.github.cukedoctor.util.Constants;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Logger;
-
-import static com.github.cukedoctor.util.Assert.hasText;
-import static com.github.cukedoctor.util.Assert.notEmpty;
+import java.util.function.Function;
+import org.slf4j.LoggerFactory;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Feature implements Comparable<Feature> {
 
-    private String id;
-    private String name;
-    private String uri;
-    private String description;
-    private String keyword;
-    private List<Scenario> elements = new ArrayList<>();
-    private List<Scenario> scenarios = new ArrayList<>();
-    private List<Tag> tags = new ArrayList<>();
-    private StepResults stepResults;
-    private ScenarioResults scenarioResults;
-    private List<Comment> comments;
-    @JsonIgnore
-    private String language;
+  private static final org.slf4j.Logger log = LoggerFactory.getLogger(Feature.class);
 
-    @JsonIgnore
-    private Integer order;
+  private String id;
+  private String name;
+  private String uri;
+  private String description;
+  private String keyword;
+  private List<Scenario> elements = new ArrayList<>();
+  private List<Scenario> scenarios = new ArrayList<>();
+  private List<Tag> tags = new ArrayList<>();
+  private StepResults stepResults;
+  private ScenarioResults scenarioResults;
+  private List<Comment> comments;
+  @JsonIgnore
+  private String language;
 
-    @JsonIgnore
-    private boolean backgroundRendered;//backgrounds runs for each scenario so we will render it only in the first one
+  @JsonIgnore
+  private Integer order;
 
+  @JsonIgnore
+  private boolean
+      backgroundRendered; // backgrounds runs for each scenario so we will render it only in the
+  // first one
 
-    public Feature() {
+  public Feature() {
+  }
 
-    }
+  public String getId() {
+    return id;
+  }
 
-    public String getId() {
-        return id;
-    }
+  public void setId(String id) {
+    this.id = id;
+  }
 
-    public void setId(String id) {
-        this.id = id;
-    }
+  public String getUri() {
+    return this.uri;
+  }
 
-    public String getUri() {
-        return this.uri;
-    }
+  public void setUri(String uri) {
+    this.uri = uri;
+  }
 
-    public void setUri(String uri) {
-        this.uri = uri;
-    }
+  public boolean hasTags() {
+    return notEmpty(tags);
+  }
 
-    public boolean hasTags() {
-        return notEmpty(tags);
-    }
+  public boolean hasScenarios() {
+    return !elements.isEmpty();
+  }
 
-    public boolean hasScenarios() {
-        return !elements.isEmpty();
-    }
+  public Status getStatus() {
+    return notEmpty(scenarioResults.getFailedScenarios()) ? Status.failed : Status.passed;
+  }
 
-    public Status getStatus() {
-        return notEmpty(scenarioResults.getFailedScenarios()) ? Status.failed : Status.passed;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public void setName(String name) {
+    this.name = name;
+  }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+  public String getDescription() {
+    return description;
+  }
 
-    public String getDescription() {
-        return description;
-    }
+  public void setDescription(String description) {
+    this.description = description;
+  }
 
-    public void setDescription(String description) {
-        this.description = description;
-    }
+  public String getKeyword() {
+    return keyword;
+  }
 
-    public String getKeyword() {
-        return keyword;
-    }
+  public void setKeyword(String keyword) {
+    this.keyword = keyword;
+  }
 
-    public void setKeyword(String keyword) {
-        this.keyword = keyword;
-    }
+  public List<Scenario> getElements() {
+    return elements;
+  }
 
-    public List<Scenario> getElements() {
-        return elements;
-    }
+  public void setElements(List<Scenario> elements) {
+    this.elements = elements;
+  }
 
-    public void setElements(List<Scenario> elements) {
-        this.elements = elements;
-    }
+  public List<Tag> getTags() {
+    return tags;
+  }
 
-    public List<Tag> getTags() {
-        return tags;
-    }
+  public void setTags(List<Tag> tags) {
+    this.tags = tags;
+  }
 
-    public void setTags(List<Tag> tags) {
-        this.tags = tags;
-    }
+  public StepResults getStepResults() {
+    return stepResults;
+  }
 
-    public StepResults getStepResults() {
-        return stepResults;
-    }
+  public ScenarioResults getScenarioResults() {
+    return scenarioResults;
+  }
 
-    public ScenarioResults getScenarioResults() {
-        return scenarioResults;
-    }
+  public List<Comment> getComments() {
+    return comments;
+  }
 
-    public List<Comment> getComments() {
-        return comments;
-    }
+  public void setComments(List<Comment> comments) {
+    this.comments = comments;
+  }
 
-    public void setComments(List<Comment> comments) {
-        this.comments = comments;
-    }
+  public boolean isBackgroundRendered() {
+    return backgroundRendered;
+  }
 
+  public void setBackgroundRendered(boolean backgroundRendered) {
+    this.backgroundRendered = backgroundRendered;
+  }
 
-    public boolean isBackgroundRendered() {
-        return backgroundRendered;
-    }
-
-
-    public void setBackgroundRendered(boolean backgroundRendered) {
-        this.backgroundRendered = backgroundRendered;
-    }
-
-
-    /**
-     * @return total number of scenarios
-     * @deprecated use {@link Feature#getScenarioResults()}
-     */
-    @Deprecated
-    public Integer getNumberOfScenarios() {
-        Integer result = 0;
-        if (scenarios != null) {
-            List<Scenario> elementList = new ArrayList<Scenario>();
-            for (Scenario element : scenarios) {
-                if (!element.hasExamples()) {
-                    elementList.add(element);
-                }
-            }
-            result = elementList.size();
+  /**
+   * @return total number of scenarios
+   * @deprecated use {@link Feature#getScenarioResults()}
+   */
+  @Deprecated
+  public Integer getNumberOfScenarios() {
+    Integer result = 0;
+    if (scenarios != null) {
+      List<Scenario> elementList = new ArrayList<Scenario>();
+      for (Scenario element : scenarios) {
+        if (!element.hasExamples()) {
+          elementList.add(element);
         }
-        return result;
+      }
+      result = elementList.size();
     }
+    return result;
+  }
 
-    public Integer getNumberOfSteps() {
-        return stepResults.getNumberOfSteps();
+  public Integer getNumberOfSteps() {
+    return stepResults.getNumberOfSteps();
+  }
+
+  public Integer getNumberOfPasses() {
+    return stepResults.getNumberOfPasses();
+  }
+
+  public Integer getNumberOfFailures() {
+    return stepResults.getNumberOfFailures();
+  }
+
+  public Integer getNumberOfPending() {
+    return stepResults.getNumberOfPending();
+  }
+
+  public Integer getNumberOfSkipped() {
+    return stepResults.getNumberOfSkipped();
+  }
+
+  public Integer getNumberOfMissing() {
+    return stepResults.getNumberOfMissing();
+  }
+
+  public Integer getNumberOfUndefined() {
+    return stepResults.getNumberOfUndefined();
+  }
+
+  public String getDurationOfSteps() {
+    return stepResults.getTotalDurationAsString();
+  }
+
+  public Integer getNumberOfScenariosPassed() {
+    return scenarioResults.getNumberOfScenariosPassed();
+  }
+
+  public Integer getNumberOfScenariosFailed() {
+    return scenarioResults.getNumberOfScenariosFailed();
+  }
+
+  public List<Scenario> getScenarios() {
+    return scenarios; // scenario & scenario outline
+  }
+
+  public void initScenarios() {
+    if (elements != null) {
+      for (Scenario element : elements) {
+        scenarios.add(element);
+      }
     }
+  }
 
-    public Integer getNumberOfPasses() {
-        return stepResults.getNumberOfPasses();
+  public void processSteps() {
+    if (!isCucumberFeature()) {
+      return;
     }
-
-    public Integer getNumberOfFailures() {
-        return stepResults.getNumberOfFailures();
+    List<Step> allSteps = new ArrayList<Step>();
+    Map<Status, AtomicInteger> statusCounter = new HashMap<>();
+    for (Status status : Status.values()) {
+      statusCounter.put(status, new AtomicInteger(0));
     }
+    List<Scenario> passedScenarios = new ArrayList<Scenario>();
+    List<Scenario> failedScenarios = new ArrayList<Scenario>();
+    long totalDuration = 0L;
 
-    public Integer getNumberOfPending() {
-        return stepResults.getNumberOfPending();
-    }
-
-    public Integer getNumberOfSkipped() {
-        return stepResults.getNumberOfSkipped();
-    }
-
-    public Integer getNumberOfMissing() {
-        return stepResults.getNumberOfMissing();
-    }
-
-    public Integer getNumberOfUndefined() {
-        return stepResults.getNumberOfUndefined();
-    }
-
-    public String getDurationOfSteps() {
-        return stepResults.getTotalDurationAsString();
-    }
-
-    public Integer getNumberOfScenariosPassed() {
-        return scenarioResults.getNumberOfScenariosPassed();
-    }
-
-    public Integer getNumberOfScenariosFailed() {
-        return scenarioResults.getNumberOfScenariosFailed();
-    }
-
-    public List<Scenario> getScenarios() {
-        return scenarios;//scenario & scenario outline
-    }
-
-    public void initScenarios() {
-        if (elements != null) {
-            for (Scenario element : elements) {
-                scenarios.add(element);
-            }
+    if (scenarios != null) {
+      for (Scenario scenario : scenarios) {
+        if (scenario.hasExamples()) {
+          continue;
         }
+        calculateScenarioStats(passedScenarios, failedScenarios, scenario);
+        if (scenario.hasSteps()) {
+          for (Step step : scenario.getSteps()) {
+            allSteps.add(step);
+            statusCounter.get(step.getStatus()).incrementAndGet();
+            totalDuration += step.getDuration();
+          }
+        }
+      }
+    }
+    scenarioResults = new ScenarioResults(passedScenarios, failedScenarios);
+    stepResults = new StepResults(allSteps, statusCounter, totalDuration);
+  }
 
+  private void calculateScenarioStats(
+      List<Scenario> passedScenarios, List<Scenario> failedScenarios, Scenario element) {
+    if (element.isBackground()) {
+      return; // background scenarios are not considered as scenrario
+    }
+    if (element.getStatus() == Status.passed) {
+      passedScenarios.add(element);
+    } else if (element.getStatus() == Status.failed) {
+      failedScenarios.add(element);
+    }
+  }
+
+  public boolean isCucumberFeature() {
+    return this.getName() != null
+        && this.getKeyword() != null
+        && (this.elements != null && !this.elements.isEmpty());
+  }
+
+  public String getLanguage() {
+
+    if (language == null && comments != null) {
+      this.language = stringExtractedFrom(comments, comment -> comment.getLanguage().orElse(null));
     }
 
-    public void processSteps() {
-        if (!isCucumberFeature()) {
-            return;
-        }
-        List<Step> allSteps = new ArrayList<Step>();
-        Map<Status, AtomicInteger> statusCounter = new HashMap<>();
-        for (Status status : Status.values()) {
-            statusCounter.put(status, new AtomicInteger(0));
-        }
-        List<Scenario> passedScenarios = new ArrayList<Scenario>();
-        List<Scenario> failedScenarios = new ArrayList<Scenario>();
-        long totalDuration = 0L;
-
-        if (scenarios != null) {
-            for (Scenario scenario : scenarios) {
-                if (scenario.hasExamples()) {
-                    continue;
-                }
-                calculateScenarioStats(passedScenarios, failedScenarios, scenario);
-                if (scenario.hasSteps()) {
-                    for (Step step : scenario.getSteps()) {
-                        allSteps.add(step);
-                        statusCounter.get(step.getStatus()).incrementAndGet();
-                        totalDuration += step.getDuration();
-                    }
-                }
-            }
-        }
-        scenarioResults = new ScenarioResults(passedScenarios, failedScenarios);
-        stepResults = new StepResults(allSteps, statusCounter, totalDuration);
+    if (language == null && hasTags()) {
+      this.language = stringExtractedFrom(getTags(), tag -> tag.getLanguage().orElse(null));
     }
 
-    private void calculateScenarioStats(List<Scenario> passedScenarios, List<Scenario> failedScenarios, Scenario element) {
-        if (element.isBackground()) {
-            return;//background scenarios are not considered as scenrario
-        }
-        if (element.getStatus() == Status.passed) {
-            passedScenarios.add(element);
-        } else if (element.getStatus() == Status.failed) {
-            failedScenarios.add(element);
-        }
+    if (language == null) {
+      this.language = "";
     }
 
+    return language;
+  }
 
-    public boolean isCucumberFeature() {
-        return this.getName() != null && this.getKeyword() != null && (this.elements != null && !this.elements.isEmpty());
+  public int getOrder() {
+    if (order == null && comments != null) {
+      this.order = tryOrderExtractedFrom(comments, comment -> comment.getOrder().orElse(null));
     }
 
-    public String getLanguage() {
-        if (language == null && comments != null) {
-            for (Comment comment : comments) {
-                trySetLanguage(comment.getLanguage(), "comment");
-            }
+    if (order == null && hasTags()) {
+      this.order = tryOrderExtractedFrom(getTags(), tag -> tag.getOrder().orElse(null));
+    }
+
+    if (order == null) {
+      this.order = Integer.MAX_VALUE;
+    }
+
+    return order;
+  }
+
+  private <T> String stringExtractedFrom(List<T> elements, Function<T, String> extractor) {
+    return elements.stream().map(extractor).filter(Assert::hasText).findFirst().orElse(null);
+  }
+
+  private <T> Integer tryOrderExtractedFrom(List<T> elements, Function<T, String> extractor) {
+    String orderAsString = stringExtractedFrom(elements, extractor);
+    try {
+      return Integer.parseInt(orderAsString);
+    } catch (Exception e) {
+      log.warn(
+          "Could not get order of feature {} from {} cause: {}",
+          name,
+          orderAsString,
+          e.getMessage());
+      return null;
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Feature feature = (Feature) o;
+
+    return Objects.equals(id, feature.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return name != null ? name.hashCode() : 42;
+  }
+
+  public boolean hasIgnoreDocsTag() {
+    if (hasTags()) {
+      for (Tag tag : tags) {
+        if (Constants.SKIP_DOCS.equalsIgnoreCase(tag.getName())) {
+          return true;
         }
+      }
+    }
+    return false;
+  }
 
-        if (order == null && hasTags()) {
-            for (Tag tag : getTags()) {
-                trySetLanguage(tag.getLanguage(), "tag");
-            }
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  @Override
+  public int compareTo(Feature other) {
+    int result = Integer.compare(getOrder(), other.getOrder());
+
+    // same order or no-order use name
+    if (result == 0) {
+      result = name.compareTo(other.getName());
+    }
+
+    return result;
+  }
+
+  public Scenario getScenarioByName(String name) {
+
+    if (hasText(name) && hasScenarios()) {
+      for (Scenario scenario : scenarios) {
+        if (hasText(scenario.getName()) && scenario.getName().trim().equals(name)) {
+          return scenario;
         }
-
-        if (language == null) {
-            this.language = "";
-        }
-
-        return language;
+      }
     }
+    return null;
+  }
 
-    public int getOrder() {
-        if (order == null && comments != null) {
-            for (Comment comment : comments) {
-                trySetOrder(comment.getOrder(), "comment");
-            }
-        }
+  public boolean hasTag(String pattern) {
+    return extractTag(pattern).isPresent();
+  }
 
-        if (order == null && hasTags()) {
-            for (Tag tag : getTags()) {
-                trySetOrder(tag.getOrder(), "tag");
-            }
-        }
-
-        if (order == null) {
-            this.order = Integer.MAX_VALUE;
-        }
-
-        return order;
+  public Optional<String> extractTag(String pattern) {
+    if (!hasTags()) {
+      return Optional.empty();
     }
-
-    private void trySetOrder(Optional<String> order, String source) {
-        if (order.isPresent() && hasText(order.get())) {
-            try {
-                this.order = Integer.parseInt(order.get());
-            } catch (Exception e) {
-                Logger.getLogger(getClass().getName())
-                      .warning(String.format("Could not get order of feature %s from %s cause: %s",
-                                             name,
-                                             source,
-                                             e.getMessage()));
-            }
-        }
-    }
-
-    private void trySetLanguage(Optional<String> language, String source) {
-        if (language.isPresent() && hasText(language.get())) {
-            try {
-                this.language = language.get();
-            } catch (Exception e) {
-                Logger.getLogger(getClass().getName())
-                      .warning(String.format("Could not get language of feature %s from %s cause: %s",
-                                             name,
-                                             source,
-                                             e.getMessage()));
-            }
-        }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Feature feature = (Feature) o;
-
-        return !(id != null ? !id.equals(feature.id) : feature.id != null);
-
-    }
-
-    @Override
-    public int hashCode() {
-        return name != null ? name.hashCode() : 42;
-    }
-
-    public boolean hasIgnoreDocsTag() {
-        if (hasTags()) {
-            for (Tag tag : tags) {
-                if (Constants.SKIP_DOCS.equalsIgnoreCase(tag.getName())) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public String toString() {
-        return name;
-    }
-
-    @Override
-    public int compareTo(Feature other) {
-        int result = Integer.compare(getOrder(), other.getOrder());
-
-        //same order or no-order use name
-        if (result == 0) {
-            result = name.compareTo(other.getName());
-        }
-
-        return result;
-
-    }
-
-    public Scenario getScenarioByName(String name) {
-
-        if (hasText(name) && hasScenarios()) {
-            for (Scenario scenario : scenarios) {
-                if (hasText(scenario.getName()) && scenario.getName().trim().equals(name)) {
-                    return scenario;
-                }
-            }
-        }
-        return null;
-    }
-
-    public boolean hasTag(String pattern) {
-        return extractTag(pattern).isPresent();
-    }
-
-    public Optional<String> extractTag(String pattern) {
-        if (!hasTags()) {
-            return Optional.empty();
-        }
-        return getTags().stream()
-                        .map(tag -> tag.extractPattern(pattern))
-                        .filter(Optional::isPresent)
-                        .map(Optional::get)
-                        .findFirst();
-    }
+    return getTags().stream()
+        .map(tag -> tag.extractPattern(pattern))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .findFirst();
+  }
 }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Tag.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Tag.java
@@ -1,43 +1,41 @@
 package com.github.cukedoctor.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
-import java.util.Optional;
-
 import static com.github.cukedoctor.util.Assert.hasText;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Tag {
 
-    private String name;
+  private String name;
 
-    public Tag() {
+  public Tag() {}
+
+  public Tag(String name) {
+    this.name = name;
+  }
+
+  public Optional<String> extractPattern(String pattern) {
+    int indexOfOrder = name.indexOf(pattern);
+    if (hasText(name) && indexOfOrder != -1) {
+      return Optional.of(name.substring(indexOfOrder + pattern.length()).trim());
     }
 
-    public Tag(String name) {
-        this.name = name;
-    }
+    return Optional.empty();
+  }
 
-    public Optional<String> extractPattern(String pattern) {
-        int indexOfOrder = name.indexOf(pattern);
-        if (hasText(name) && indexOfOrder != -1) {
-            return Optional.of(name.substring(indexOfOrder + pattern.length()).trim());
-        }
+  public String getName() {
+    return name;
+  }
 
-        return Optional.empty();
-    }
+  public boolean isOrder() {
+    return getOrder().isPresent();
+  }
 
-    public String getName() {
-        return name;
-    }
-
-    public boolean isOrder() {
-        return getOrder().isPresent();
-    }
-
-    public Optional<String> getOrder() {
-        return extractPattern("@order-");
-    }
+  public Optional<String> getOrder() {
+    return extractPattern("@order-");
+  }
 
   public boolean isDiscrete() {
     return extractPattern("@asciidoc").isPresent();

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Tag.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Tag.java
@@ -39,15 +39,15 @@ public class Tag {
         return extractPattern("@order-");
     }
 
-    public boolean isDiscrete() {
-        return extractPattern("@asciidoc").isPresent();
-    }
+  public boolean isDiscrete() {
+    return extractPattern("@asciidoc").isPresent();
+  }
 
-    public boolean isLanguage() {
-        return getLanguage().isPresent();
-    }
+  public boolean isLanguage() {
+    return getLanguage().isPresent();
+  }
 
-    public Optional<String> getLanguage() {
-        return extractPattern("@language-");
-    }
+  public Optional<String> getLanguage() {
+    return extractPattern("@language-");
+  }
 }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Tag.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Tag.java
@@ -1,41 +1,43 @@
 package com.github.cukedoctor.api.model;
 
-import static com.github.cukedoctor.util.Assert.hasText;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.Optional;
+
+import static com.github.cukedoctor.util.Assert.hasText;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Tag {
 
-  private String name;
+    private String name;
 
-  public Tag() {}
-
-  public Tag(String name) {
-    this.name = name;
-  }
-
-  public Optional<String> extractPattern(String pattern) {
-    int indexOfOrder = name.indexOf(pattern);
-    if (hasText(name) && indexOfOrder != -1) {
-      return Optional.of(name.substring(indexOfOrder + pattern.length()).trim());
+    public Tag() {
     }
 
-    return Optional.empty();
-  }
+    public Tag(String name) {
+        this.name = name;
+    }
 
-  public String getName() {
-    return name;
-  }
+    public Optional<String> extractPattern(String pattern) {
+        int indexOfOrder = name.indexOf(pattern);
+        if (hasText(name) && indexOfOrder != -1) {
+            return Optional.of(name.substring(indexOfOrder + pattern.length()).trim());
+        }
 
-  public boolean isOrder() {
-    return getOrder().isPresent();
-  }
+        return Optional.empty();
+    }
 
-  public Optional<String> getOrder() {
-    return extractPattern("@order-");
-  }
+    public String getName() {
+        return name;
+    }
+
+    public boolean isOrder() {
+        return getOrder().isPresent();
+    }
+
+    public Optional<String> getOrder() {
+        return extractPattern("@order-");
+    }
 
     public boolean isDiscrete() {
         return extractPattern("@asciidoc").isPresent();
@@ -49,4 +51,3 @@ public class Tag {
         return extractPattern("@language-");
     }
 }
-

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Tag.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Tag.java
@@ -37,7 +37,16 @@ public class Tag {
     return extractPattern("@order-");
   }
 
-  public boolean isDiscrete() {
-    return extractPattern("@asciidoc").isPresent();
-  }
+    public boolean isDiscrete() {
+        return extractPattern("@asciidoc").isPresent();
+    }
+
+    public boolean isLanguage() {
+        return getLanguage().isPresent();
+    }
+
+    public Optional<String> getLanguage() {
+        return extractPattern("@language-");
+    }
 }
+

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorTagsRenderer.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorTagsRenderer.java
@@ -4,53 +4,54 @@ import com.github.cukedoctor.api.model.Feature;
 import com.github.cukedoctor.api.model.Scenario;
 import com.github.cukedoctor.api.model.Tag;
 import com.github.cukedoctor.spi.TagsRenderer;
+
 import java.util.HashSet;
 import java.util.List;
 
-/** Created by pestano on 28/02/16. */
+/**
+ * Created by pestano on 28/02/16.
+ */
 public class CukedoctorTagsRenderer extends AbstractBaseRenderer implements TagsRenderer {
 
-  @Override
-  public String renderScenarioTags(Feature feature, Scenario scenario) {
-    docBuilder.clear();
+    @Override
+    public String renderScenarioTags(Feature feature, Scenario scenario) {
+        docBuilder.clear();
 
-    int expectedSize =
-        (feature.hasTags() ? feature.getTags().size() : 0)
-            + (scenario.hasTags() ? scenario.getTags().size() : 0);
-    if (expectedSize == 0) return "";
+        int expectedSize = (feature.hasTags() ? feature.getTags().size() : 0) + (scenario.hasTags() ? scenario.getTags().size() : 0);
+        if (expectedSize == 0) return "";
 
-    HashSet<String> tagNames = new HashSet<>(expectedSize);
-    extractTagNames(tagNames, feature.getTags());
-    extractTagNames(tagNames, scenario.getTags());
-    if (tagNames.size() == 0) return "";
+        HashSet<String> tagNames = new HashSet<>(expectedSize);
+        extractTagNames(tagNames, feature.getTags());
+        extractTagNames(tagNames, scenario.getTags());
+        if (tagNames.size() == 0) return "";
 
-    docBuilder.clear();
-    StringBuilder tags = new StringBuilder("[small]#tags: ");
-    for (String tagName : tagNames) {
-      tags.append(tagName).append(",");
+        docBuilder.clear();
+        StringBuilder tags = new StringBuilder("[small]#tags: ");
+        for (String tagName : tagNames) {
+            tags.append(tagName).append(",");
+        }
+
+        if (tags.indexOf(",") != -1) {//delete last comma
+            tags.deleteCharAt(tags.lastIndexOf(","));
+        }
+
+        tags.append("#");
+        docBuilder.textLine(tags.toString());
+        docBuilder.newLine();
+        return docBuilder.toString();
     }
 
-    if (tags.indexOf(",") != -1) { // delete last comma
-      tags.deleteCharAt(tags.lastIndexOf(","));
+    private void extractTagNames(HashSet<String> tagNames, List<Tag> tags) {
+        if (tags == null) return;
+
+        for (Tag tag : tags) {
+            if (!isCukedoctorTag(tag)) {
+                tagNames.add(tag.getName());
+            }
+        }
     }
 
-    tags.append("#");
-    docBuilder.textLine(tags.toString());
-    docBuilder.newLine();
-    return docBuilder.toString();
-  }
-
-  private void extractTagNames(HashSet<String> tagNames, List<Tag> tags) {
-    if (tags == null) return;
-
-    for (Tag tag : tags) {
-      if (!isCukedoctorTag(tag)) {
-        tagNames.add(tag.getName());
-      }
+    protected boolean isCukedoctorTag(Tag tag) {
+        return tag.isOrder() || tag.isLanguage() || tag.isDiscrete();
     }
-  }
-
-  protected boolean isCukedoctorTag(Tag tag) {
-    return tag.isOrder() || tag.isLanguage() || tag.isDiscrete();
-  }
 }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorTagsRenderer.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorTagsRenderer.java
@@ -4,54 +4,53 @@ import com.github.cukedoctor.api.model.Feature;
 import com.github.cukedoctor.api.model.Scenario;
 import com.github.cukedoctor.api.model.Tag;
 import com.github.cukedoctor.spi.TagsRenderer;
-
 import java.util.HashSet;
 import java.util.List;
 
-/**
- * Created by pestano on 28/02/16.
- */
+/** Created by pestano on 28/02/16. */
 public class CukedoctorTagsRenderer extends AbstractBaseRenderer implements TagsRenderer {
 
-    @Override
-    public String renderScenarioTags(Feature feature, Scenario scenario) {
-        docBuilder.clear();
+  @Override
+  public String renderScenarioTags(Feature feature, Scenario scenario) {
+    docBuilder.clear();
 
-        int expectedSize = (feature.hasTags() ? feature.getTags().size() : 0) + (scenario.hasTags() ? scenario.getTags().size() : 0);
-        if (expectedSize == 0) return "";
+    int expectedSize =
+        (feature.hasTags() ? feature.getTags().size() : 0)
+            + (scenario.hasTags() ? scenario.getTags().size() : 0);
+    if (expectedSize == 0) return "";
 
-        HashSet<String> tagNames = new HashSet<>(expectedSize);
-        extractTagNames(tagNames, feature.getTags());
-        extractTagNames(tagNames, scenario.getTags());
-        if (tagNames.size() == 0) return "";
+    HashSet<String> tagNames = new HashSet<>(expectedSize);
+    extractTagNames(tagNames, feature.getTags());
+    extractTagNames(tagNames, scenario.getTags());
+    if (tagNames.size() == 0) return "";
 
-        docBuilder.clear();
-        StringBuilder tags = new StringBuilder("[small]#tags: ");
-        for (String tagName : tagNames) {
-            tags.append(tagName).append(",");
-        }
-
-        if (tags.indexOf(",") != -1) {//delete last comma
-            tags.deleteCharAt(tags.lastIndexOf(","));
-        }
-
-        tags.append("#");
-        docBuilder.textLine(tags.toString());
-        docBuilder.newLine();
-        return docBuilder.toString();
+    docBuilder.clear();
+    StringBuilder tags = new StringBuilder("[small]#tags: ");
+    for (String tagName : tagNames) {
+      tags.append(tagName).append(",");
     }
 
-    private void extractTagNames(HashSet<String> tagNames, List<Tag> tags) {
-        if (tags == null) return;
-
-        for (Tag tag : tags) {
-            if (!isCukedoctorTag(tag)) {
-                tagNames.add(tag.getName());
-            }
-        }
+    if (tags.indexOf(",") != -1) { // delete last comma
+      tags.deleteCharAt(tags.lastIndexOf(","));
     }
 
-    protected boolean isCukedoctorTag(Tag tag) {
-        return tag.isOrder() || tag.isLanguage() || tag.isDiscrete();
+    tags.append("#");
+    docBuilder.textLine(tags.toString());
+    docBuilder.newLine();
+    return docBuilder.toString();
+  }
+
+  private void extractTagNames(HashSet<String> tagNames, List<Tag> tags) {
+    if (tags == null) return;
+
+    for (Tag tag : tags) {
+      if (!isCukedoctorTag(tag)) {
+        tagNames.add(tag.getName());
+      }
     }
+  }
+
+  protected boolean isCukedoctorTag(Tag tag) {
+    return tag.isOrder() || tag.isLanguage() || tag.isDiscrete();
+  }
 }

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorTagsRenderer.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorTagsRenderer.java
@@ -51,6 +51,6 @@ public class CukedoctorTagsRenderer extends AbstractBaseRenderer implements Tags
   }
 
   protected boolean isCukedoctorTag(Tag tag) {
-    return tag.isOrder() || tag.isDiscrete();
+    return tag.isOrder() || tag.isLanguage() || tag.isDiscrete();
   }
 }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/i18n/I18nLoaderTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/i18n/I18nLoaderTest.java
@@ -20,45 +20,50 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(JUnit4.class)
 public class I18nLoaderTest {
 
-    private static List<Feature> englishFeatures;
-    private static List<Feature> noLanguageFeatures;
-    private static List<Feature> portugueseFeatures;
-    private static List<Feature> spanishFeatures;
-    private static List<Feature> frenchFeatures;
-    private static List<Feature> portugueseTagFeatures;
-    private static List<Feature> spanishTagFeatures;
-    private static List<Feature> frenchTagFeatures;
+  private static List<Feature> englishFeatures;
+  private static List<Feature> noLanguageFeatures;
+  private static List<Feature> portugueseFeatures;
+  private static List<Feature> spanishFeatures;
+  private static List<Feature> frenchFeatures;
+  private static List<Feature> portugueseTagFeatures;
+  private static List<Feature> spanishTagFeatures;
+  private static List<Feature> frenchTagFeatures;
 
-
-
-    @BeforeClass
-    public static void loadFeatures() {
-        String englishFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/english.json");
-        String portugueseFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/portuguese.json");
-        String spanishFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/spanish.json");
-        String frenchFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/french.json");
-        String portugueseTagFeature = FileUtil.findJsonFile(
-                "target/test-classes/json-output/i18n/portuguese_with_tag.json");
-        String spanishTagFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/spanish_with_tag.json");
-        String frenchTagFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/french_with_tag.json");
-        String noLanguageFeature = FileUtil.findJsonFile("target/test-classes/json-output/outline.json");
-        englishFeatures = FeatureParser.parse(englishFeature);
-        portugueseFeatures = FeatureParser.parse(portugueseFeature);
-        spanishFeatures = FeatureParser.parse(spanishFeature);
-        frenchFeatures = FeatureParser.parse(frenchFeature);
-        portugueseTagFeatures = FeatureParser.parse(portugueseTagFeature);
-        spanishTagFeatures = FeatureParser.parse(spanishTagFeature);
-        frenchTagFeatures = FeatureParser.parse(frenchTagFeature);
-        noLanguageFeatures = FeatureParser.parse(noLanguageFeature);
-        assertNotNull(englishFeatures);
-        assertNotNull(portugueseFeatures);
-        assertNotNull(spanishFeatures);
-        assertNotNull(frenchFeatures);
-        assertNotNull(portugueseTagFeatures);
-        assertNotNull(spanishTagFeatures);
-        assertNotNull(frenchTagFeatures);
-        assertNotNull(noLanguageFeatures);
-    }
+  @BeforeClass
+  public static void loadFeatures() {
+    String englishFeature =
+        FileUtil.findJsonFile("target/test-classes/json-output/i18n/english.json");
+    String portugueseFeature =
+        FileUtil.findJsonFile("target/test-classes/json-output/i18n/portuguese.json");
+    String spanishFeature =
+        FileUtil.findJsonFile("target/test-classes/json-output/i18n/spanish.json");
+    String frenchFeature =
+        FileUtil.findJsonFile("target/test-classes/json-output/i18n/french.json");
+    String portugueseTagFeature =
+        FileUtil.findJsonFile("target/test-classes/json-output/i18n/portuguese_with_tag.json");
+    String spanishTagFeature =
+        FileUtil.findJsonFile("target/test-classes/json-output/i18n/spanish_with_tag.json");
+    String frenchTagFeature =
+        FileUtil.findJsonFile("target/test-classes/json-output/i18n/french_with_tag.json");
+    String noLanguageFeature =
+        FileUtil.findJsonFile("target/test-classes/json-output/outline.json");
+    englishFeatures = FeatureParser.parse(englishFeature);
+    portugueseFeatures = FeatureParser.parse(portugueseFeature);
+    spanishFeatures = FeatureParser.parse(spanishFeature);
+    frenchFeatures = FeatureParser.parse(frenchFeature);
+    portugueseTagFeatures = FeatureParser.parse(portugueseTagFeature);
+    spanishTagFeatures = FeatureParser.parse(spanishTagFeature);
+    frenchTagFeatures = FeatureParser.parse(frenchTagFeature);
+    noLanguageFeatures = FeatureParser.parse(noLanguageFeature);
+    assertNotNull(englishFeatures);
+    assertNotNull(portugueseFeatures);
+    assertNotNull(spanishFeatures);
+    assertNotNull(frenchFeatures);
+    assertNotNull(portugueseTagFeatures);
+    assertNotNull(spanishTagFeatures);
+    assertNotNull(frenchTagFeatures);
+    assertNotNull(noLanguageFeatures);
+  }
 
     @AfterClass
     public static void resetBackToDefaultLanguage() {
@@ -89,37 +94,37 @@ public class I18nLoaderTest {
         assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Pasos");
     }
 
-    @Test
-    public void shouldLoadFrenchBundle(){
-        I18nLoader i18nLoader = I18nLoader.newInstance(frenchFeatures);
-        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Fonctionnalités");
-        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Sommaire");
-        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Étapes");
-    }
+  @Test
+  public void shouldLoadFrenchBundle() {
+    I18nLoader i18nLoader = I18nLoader.newInstance(frenchFeatures);
+    assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Fonctionnalités");
+    assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Sommaire");
+    assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Étapes");
+  }
 
-    @Test
-    public void shouldLoadPortugueseBundleFromTag(){
-        I18nLoader i18nLoader = I18nLoader.newInstance(portugueseTagFeatures);
-        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Funcionalidades");
-        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumo");
-        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Passos");
-    }
+  @Test
+  public void shouldLoadPortugueseBundleFromTag() {
+    I18nLoader i18nLoader = I18nLoader.newInstance(portugueseTagFeatures);
+    assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Funcionalidades");
+    assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumo");
+    assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Passos");
+  }
 
-    @Test
-    public void shouldLoadSpanishBundleFromTag(){
-        I18nLoader i18nLoader = I18nLoader.newInstance(spanishTagFeatures);
-        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Características");
-        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumen");
-        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Pasos");
-    }
+  @Test
+  public void shouldLoadSpanishBundleFromTag() {
+    I18nLoader i18nLoader = I18nLoader.newInstance(spanishTagFeatures);
+    assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Características");
+    assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumen");
+    assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Pasos");
+  }
 
-    @Test
-    public void shouldLoadFrenchBundleFromTag(){
-        I18nLoader i18nLoader = I18nLoader.newInstance(frenchTagFeatures);
-        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Fonctionnalités");
-        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Sommaire");
-        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Étapes");
-    }
+  @Test
+  public void shouldLoadFrenchBundleFromTag() {
+    I18nLoader i18nLoader = I18nLoader.newInstance(frenchTagFeatures);
+    assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Fonctionnalités");
+    assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Sommaire");
+    assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Étapes");
+  }
 
     @Test
     public void shouldLoadEnglishBundleForFeaturesWithNoLanguage(){

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/i18n/I18nLoaderTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/i18n/I18nLoaderTest.java
@@ -17,35 +17,45 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class I18nLoaderTest {
 
-  private static List<Feature> englishFeatures;
-  private static List<Feature> noLanguageFeatures;
-  private static List<Feature> portugueseFeatures;
-  private static List<Feature> spanishFeatures;
-  private static List<Feature> frenchFeatures;
+    private static List<Feature> englishFeatures;
+    private static List<Feature> noLanguageFeatures;
+    private static List<Feature> portugueseFeatures;
+    private static List<Feature> spanishFeatures;
+    private static List<Feature> frenchFeatures;
+    private static List<Feature> portugueseTagFeatures;
+    private static List<Feature> spanishTagFeatures;
+    private static List<Feature> frenchTagFeatures;
 
-  @BeforeClass
-  public static void loadFeatures() {
-    String englishFeature =
-        FileUtil.findJsonFile("target/test-classes/json-output/i18n/english.json");
-    String portugueseFeature =
-        FileUtil.findJsonFile("target/test-classes/json-output/i18n/portuguese.json");
-    String spanishFeature =
-        FileUtil.findJsonFile("target/test-classes/json-output/i18n/spanish.json");
-    String frenchFeature =
-        FileUtil.findJsonFile("target/test-classes/json-output/i18n/french.json");
-    String noLanguageFeature =
-        FileUtil.findJsonFile("target/test-classes/json-output/outline.json");
-    englishFeatures = FeatureParser.parse(englishFeature);
-    portugueseFeatures = FeatureParser.parse(portugueseFeature);
-    spanishFeatures = FeatureParser.parse(spanishFeature);
-    frenchFeatures = FeatureParser.parse(frenchFeature);
-    noLanguageFeatures = FeatureParser.parse(noLanguageFeature);
-    assertNotNull(englishFeatures);
-    assertNotNull(portugueseFeatures);
-    assertNotNull(spanishFeatures);
-    assertNotNull(frenchFeatures);
-    assertNotNull(noLanguageFeatures);
-  }
+
+
+    @BeforeClass
+    public static void loadFeatures() {
+        String englishFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/english.json");
+        String portugueseFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/portuguese.json");
+        String spanishFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/spanish.json");
+        String frenchFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/french.json");
+        String portugueseTagFeature = FileUtil.findJsonFile(
+                "target/test-classes/json-output/i18n/portuguese_with_tag.json");
+        String spanishTagFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/spanish_with_tag.json");
+        String frenchTagFeature = FileUtil.findJsonFile("target/test-classes/json-output/i18n/french_with_tag.json");
+        String noLanguageFeature = FileUtil.findJsonFile("target/test-classes/json-output/outline.json");
+        englishFeatures = FeatureParser.parse(englishFeature);
+        portugueseFeatures = FeatureParser.parse(portugueseFeature);
+        spanishFeatures = FeatureParser.parse(spanishFeature);
+        frenchFeatures = FeatureParser.parse(frenchFeature);
+        portugueseTagFeatures = FeatureParser.parse(portugueseTagFeature);
+        spanishTagFeatures = FeatureParser.parse(spanishTagFeature);
+        frenchTagFeatures = FeatureParser.parse(frenchTagFeature);
+        noLanguageFeatures = FeatureParser.parse(noLanguageFeature);
+        assertNotNull(englishFeatures);
+        assertNotNull(portugueseFeatures);
+        assertNotNull(spanishFeatures);
+        assertNotNull(frenchFeatures);
+        assertNotNull(portugueseTagFeatures);
+        assertNotNull(spanishTagFeatures);
+        assertNotNull(frenchTagFeatures);
+        assertNotNull(noLanguageFeatures);
+    }
 
   @AfterClass
   public static void resetBackToDefaultLanguage() {
@@ -76,13 +86,37 @@ public class I18nLoaderTest {
     assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Pasos");
   }
 
-  @Test
-  public void shouldLoadFrenchBundle() {
-    I18nLoader i18nLoader = I18nLoader.newInstance(frenchFeatures);
-    assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Fonctionnalités");
-    assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Sommaire");
-    assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Étapes");
-  }
+    @Test
+    public void shouldLoadFrenchBundle(){
+        I18nLoader i18nLoader = I18nLoader.newInstance(frenchFeatures);
+        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Fonctionnalités");
+        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Sommaire");
+        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Étapes");
+    }
+
+    @Test
+    public void shouldLoadPortugueseBundleFromTag(){
+        I18nLoader i18nLoader = I18nLoader.newInstance(portugueseTagFeatures);
+        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Funcionalidades");
+        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumo");
+        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Passos");
+    }
+
+    @Test
+    public void shouldLoadSpanishBundleFromTag(){
+        I18nLoader i18nLoader = I18nLoader.newInstance(spanishTagFeatures);
+        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Características");
+        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumen");
+        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Pasos");
+    }
+
+    @Test
+    public void shouldLoadFrenchBundleFromTag(){
+        I18nLoader i18nLoader = I18nLoader.newInstance(frenchTagFeatures);
+        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Fonctionnalités");
+        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Sommaire");
+        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Étapes");
+    }
 
   @Test
   public void shouldLoadEnglishBundleForFeaturesWithNoLanguage() {

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/i18n/I18nLoaderTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/i18n/I18nLoaderTest.java
@@ -1,19 +1,22 @@
 package com.github.cukedoctor.i18n;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
-
 import com.github.cukedoctor.api.model.Feature;
 import com.github.cukedoctor.parser.FeatureParser;
 import com.github.cukedoctor.util.FileUtil;
-import java.util.List;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Created by pestano on 19/02/16. */
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Created by pestano on 19/02/16.
+ */
 @RunWith(JUnit4.class)
 public class I18nLoaderTest {
 
@@ -57,34 +60,34 @@ public class I18nLoaderTest {
         assertNotNull(noLanguageFeatures);
     }
 
-  @AfterClass
-  public static void resetBackToDefaultLanguage() {
-    I18nLoader.newInstance(null);
-  }
+    @AfterClass
+    public static void resetBackToDefaultLanguage() {
+        I18nLoader.newInstance(null);
+    }
 
-  @Test
-  public void shouldLoadEnglishBundle() {
-    I18nLoader i18nLoader = I18nLoader.newInstance(englishFeatures);
-    assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Features");
-    assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Summary");
-    assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Steps");
-  }
+    @Test
+    public void shouldLoadEnglishBundle(){
+        I18nLoader i18nLoader = I18nLoader.newInstance(englishFeatures);
+        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Features");
+        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Summary");
+        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Steps");
+    }
 
-  @Test
-  public void shouldLoadPortugueseBundle() {
-    I18nLoader i18nLoader = I18nLoader.newInstance(portugueseFeatures);
-    assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Funcionalidades");
-    assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumo");
-    assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Passos");
-  }
+    @Test
+    public void shouldLoadPortugueseBundle(){
+        I18nLoader i18nLoader = I18nLoader.newInstance(portugueseFeatures);
+        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Funcionalidades");
+        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumo");
+        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Passos");
+    }
 
-  @Test
-  public void shouldLoadSpanishBundle() {
-    I18nLoader i18nLoader = I18nLoader.newInstance(spanishFeatures);
-    assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Características");
-    assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumen");
-    assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Pasos");
-  }
+    @Test
+    public void shouldLoadSpanishBundle(){
+        I18nLoader i18nLoader = I18nLoader.newInstance(spanishFeatures);
+        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Características");
+        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumen");
+        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Pasos");
+    }
 
     @Test
     public void shouldLoadFrenchBundle(){
@@ -118,11 +121,11 @@ public class I18nLoaderTest {
         assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Étapes");
     }
 
-  @Test
-  public void shouldLoadEnglishBundleForFeaturesWithNoLanguage() {
-    I18nLoader i18nLoader = I18nLoader.newInstance(noLanguageFeatures);
-    assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Features");
-    assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Summary");
-    assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Steps");
-  }
+    @Test
+    public void shouldLoadEnglishBundleForFeaturesWithNoLanguage(){
+        I18nLoader i18nLoader = I18nLoader.newInstance(noLanguageFeatures);
+        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Features");
+        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Summary");
+        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Steps");
+    }
 }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/i18n/I18nLoaderTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/i18n/I18nLoaderTest.java
@@ -1,22 +1,19 @@
 package com.github.cukedoctor.i18n;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
 import com.github.cukedoctor.api.model.Feature;
 import com.github.cukedoctor.parser.FeatureParser;
 import com.github.cukedoctor.util.FileUtil;
+import java.util.List;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
-
-/**
- * Created by pestano on 19/02/16.
- */
+/** Created by pestano on 19/02/16. */
 @RunWith(JUnit4.class)
 public class I18nLoaderTest {
 
@@ -65,34 +62,34 @@ public class I18nLoaderTest {
     assertNotNull(noLanguageFeatures);
   }
 
-    @AfterClass
-    public static void resetBackToDefaultLanguage() {
-        I18nLoader.newInstance(null);
-    }
+  @AfterClass
+  public static void resetBackToDefaultLanguage() {
+    I18nLoader.newInstance(null);
+  }
 
-    @Test
-    public void shouldLoadEnglishBundle(){
-        I18nLoader i18nLoader = I18nLoader.newInstance(englishFeatures);
-        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Features");
-        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Summary");
-        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Steps");
-    }
+  @Test
+  public void shouldLoadEnglishBundle() {
+    I18nLoader i18nLoader = I18nLoader.newInstance(englishFeatures);
+    assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Features");
+    assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Summary");
+    assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Steps");
+  }
 
-    @Test
-    public void shouldLoadPortugueseBundle(){
-        I18nLoader i18nLoader = I18nLoader.newInstance(portugueseFeatures);
-        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Funcionalidades");
-        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumo");
-        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Passos");
-    }
+  @Test
+  public void shouldLoadPortugueseBundle() {
+    I18nLoader i18nLoader = I18nLoader.newInstance(portugueseFeatures);
+    assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Funcionalidades");
+    assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumo");
+    assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Passos");
+  }
 
-    @Test
-    public void shouldLoadSpanishBundle(){
-        I18nLoader i18nLoader = I18nLoader.newInstance(spanishFeatures);
-        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Características");
-        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumen");
-        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Pasos");
-    }
+  @Test
+  public void shouldLoadSpanishBundle() {
+    I18nLoader i18nLoader = I18nLoader.newInstance(spanishFeatures);
+    assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Características");
+    assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Resumen");
+    assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Pasos");
+  }
 
   @Test
   public void shouldLoadFrenchBundle() {
@@ -126,11 +123,11 @@ public class I18nLoaderTest {
     assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Étapes");
   }
 
-    @Test
-    public void shouldLoadEnglishBundleForFeaturesWithNoLanguage(){
-        I18nLoader i18nLoader = I18nLoader.newInstance(noLanguageFeatures);
-        assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Features");
-        assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Summary");
-        assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Steps");
-    }
+  @Test
+  public void shouldLoadEnglishBundleForFeaturesWithNoLanguage() {
+    I18nLoader i18nLoader = I18nLoader.newInstance(noLanguageFeatures);
+    assertThat(i18nLoader.getMessage("title.features")).isEqualTo("Features");
+    assertThat(i18nLoader.getMessage("title.summary")).isEqualTo("Summary");
+    assertThat(i18nLoader.getMessage("summary.steps")).isEqualTo("Steps");
+  }
 }

--- a/cukedoctor-converter/src/test/resources/json-output/i18n/french_with_tag.json
+++ b/cukedoctor-converter/src/test/resources/json-output/i18n/french_with_tag.json
@@ -1,0 +1,64 @@
+[
+  {
+    "line": 2,
+    "elements": [
+      {
+        "start_timestamp": "2022-07-21T08:24:32.069Z",
+        "line": 11,
+        "name": "L'API Open API est disponible sur demande",
+        "description": "",
+        "id": "l-api-swagger-est-disponible;l-api-open-api-est-disponible-sur-demande",
+        "type": "scenario",
+        "keyword": "Scénario",
+        "steps": [
+          {
+            "result": {
+              "duration": 148430000,
+              "status": "passed"
+            },
+            "line": 12,
+            "name": "l'application est active",
+            "match": {
+              "location": "org.rdlopes.cukedoctor.features.steps.RestOperationsSteps.applicationIsUp()"
+            },
+            "keyword": "Etant donné que "
+          },
+          {
+            "result": {
+              "duration": 274399000,
+              "status": "passed"
+            },
+            "line": 13,
+            "name": "je demande à obtenir les spécifications de l'API",
+            "match": {
+              "location": "org.rdlopes.cukedoctor.features.steps.RestOperationsSteps.iRequestTheOpenAPISpecifications()"
+            },
+            "keyword": "Quand "
+          },
+          {
+            "result": {
+              "duration": 4886000,
+              "status": "passed"
+            },
+            "line": 14,
+            "name": "je reçois les spécifications",
+            "match": {
+              "location": "org.rdlopes.cukedoctor.features.steps.RestOperationsSteps.iReceiveTheSpecsForTheApplication()"
+            },
+            "keyword": "Alors "
+          }
+        ]
+      }
+    ],
+    "name": "L'API Swagger est disponible",
+    "description": "  [quote]\n  ====\n  En tant que développeur,\n  je veux pouvoir accéder aux spécifications de l'Open API\n  afin de comprendre comment interagir avec l'application\n  ====",
+    "id": "l-api-swagger-est-disponible",
+    "keyword": "Fonctionnalité",
+    "uri": "classpath:features/01_plateforme/01_documentation.feature",
+    "tags": [
+      {
+        "name": "@language-fr"
+      }
+    ]
+  }
+]

--- a/cukedoctor-converter/src/test/resources/json-output/i18n/portuguese_with_tag.json
+++ b/cukedoctor-converter/src/test/resources/json-output/i18n/portuguese_with_tag.json
@@ -1,0 +1,149 @@
+[
+  {
+    "line": 3,
+    "elements": [
+      {
+        "line": 8,
+        "name": "Generate documentation of a single file",
+        "description": "",
+        "id": "cukedoctor-main;generate-documentation-of-a-single-file",
+        "type": "scenario",
+        "keyword": "Cenário",
+        "steps": [
+          {
+            "result": {
+              "duration": 187536110,
+              "status": "passed"
+            },
+            "line": 9,
+            "name": "A Cucumber json execution file is are already generated",
+            "match": {
+              "location": "CukedoctorMainSteps.A_Cucumber_json_execution_file_is_are_already_generated()"
+            },
+            "keyword": "Dado "
+          },
+          {
+            "result": {
+              "duration": 17662354279,
+              "status": "passed"
+            },
+            "line": 10,
+            "name": "I execute CukedoctorMain with args \"-o target/test-classes/outputFile.adoc\" \"-p target/test-classes/json-output/one_passing_one_failing.json\" and \"-t Documentation\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "-o target/test-classes/outputFile.adoc",
+                  "offset": 36
+                },
+                {
+                  "val": "-p target/test-classes/json-output/one_passing_one_failing.json",
+                  "offset": 77
+                },
+                {
+                  "val": "-t Documentation",
+                  "offset": 147
+                }
+              ],
+              "location": "CukedoctorMainSteps.I_execute_CukedoctorMain_with_args_and(String,String,String)"
+            },
+            "keyword": "Quando "
+          },
+          {
+            "result": {
+              "duration": 2905877,
+              "error_message": "org.junit.ComparisonFailure: expected:\u003c...0|0|22+|010ms|\u003d\u003d\u003d\u003d\u003d*[Features]*[[One-passing-scena...\u003e but was:\u003c...0|0|22+|010ms|\u003d\u003d\u003d\u003d\u003d*[??title.features??]*[[One-passing-scena...\u003e\n\tat org.junit.Assert.assertEquals(Assert.java:115)\n\tat org.junit.Assert.assertEquals(Assert.java:144)\n\tat com.github.cukedoctor.bdd.CukedoctorMainSteps.A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(CukedoctorMainSteps.java:44)\n\tat ✽.Então A file named outputFile.adoc should be generated with the following content:(src/test/resources/features/cukedoctor_main.feature:11)\n",
+              "status": "failed"
+            },
+            "line": 11,
+            "name": "A file named outputFile.adoc should be generated with the following content:",
+            "match": {
+              "location": "CukedoctorMainSteps.A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(String)"
+            },
+            "keyword": "Então ",
+            "doc_string": {
+              "content_type": "",
+              "line": 12,
+              "value": " :toc: right\n:backend: html5\n:doctitle: Documentation\n:doctype: book\n:icons: font\n:sectanchors:\n:sectlink:\n:docinfo:\n:source-highlighter: highlightjs\n:toclevels: 3\n:hardbreaks:\n\n\u003d *Documentation*\n\n\u003d\u003d *Summary*\n[cols\u003d\"12*^m\", options\u003d\"header,footer\"]\n|\u003d\u003d\u003d\n3+|Scenarios 7+|Steps 2+|Features: 1\n\n|[green]#*Passed*#\n|[red]#*Failed*#\n|Total\n|[green]#*Passed*#\n|[red]#*Failed*#\n|[purple]#*Skipped*#\n|[maroon]#*Pending*#\n|[yellow]#*Undefined*#\n|[blue]#*Missing*#\n|Total\n|Duration\n|Status\n\n12+^|*\u003c\u003cOne-passing-scenario-one-failing-scenario\u003e\u003e*\n|1\n|1\n|2\n|1\n|1\n|0\n|0\n|0\n|0\n|2\n|010ms\n|[red]#*failed*#\n12+^|*Totals*\n|1|1|2|1|1|0|0|0|0|2 2+|010ms\n|\u003d\u003d\u003d\n\n\u003d\u003d *Features*\n\n[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing scenario]]\n\u003d\u003d\u003d *One passing scenario, one failing scenario*\n\nminmax::One-passing-scenario-one-failing-scenario[]\n\u003d\u003d\u003d\u003d Scenario: Passing\n[small]#tags: @a,@b#\n\n****\nGiven ::\nthis step passes icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(001ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario: Failing\n[small]#tags: @a,@c#\n\n****\nGiven ::\nthis step fails icon:thumbs-down[role\u003d\"red\",title\u003d\"Failed\"] [small right]#(008ms)#\n\nIMPORTANT:  (RuntimeError)\n./features/step_definitions/steps.rb:4:in /^this step fails$/\u0027\nfeatures/one_passing_one_failing.feature:10:in Given this step fails\u0027\n****"
+            }
+          }
+        ]
+      },
+      {
+        "line": 92,
+        "name": "Generate documentation using multiple files",
+        "description": "",
+        "id": "cukedoctor-main;generate-documentation-using-multiple-files",
+        "type": "scenario",
+        "keyword": "Cenário",
+        "steps": [
+          {
+            "result": {
+              "duration": 60580,
+              "status": "passed"
+            },
+            "line": 93,
+            "name": "Cucumber multiple json execution files are already generate",
+            "match": {
+              "location": "CukedoctorMainSteps.Cucumber_multiple_json_execution_files_are_already_generate()"
+            },
+            "keyword": "Dado "
+          },
+          {
+            "result": {
+              "duration": 1194378335,
+              "status": "passed"
+            },
+            "line": 94,
+            "name": "I execute CukedoctorMain with args \"-o target/test-classes/outputFile.adoc\" \"-p target/test-classes/json-output/\" and \"-t Documentation\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "-o target/test-classes/outputFile.adoc",
+                  "offset": 36
+                },
+                {
+                  "val": "-p target/test-classes/json-output/",
+                  "offset": 77
+                },
+                {
+                  "val": "-t Documentation",
+                  "offset": 119
+                }
+              ],
+              "location": "CukedoctorMainSteps.I_execute_CukedoctorMain_with_args_and(String,String,String)"
+            },
+            "keyword": "Quando "
+          },
+          {
+            "result": {
+              "duration": 1774892,
+              "error_message": "org.junit.ComparisonFailure: expected:\u003c...|92+|10s114ms|\u003d\u003d\u003d\u003d\u003d*[Features]*[[An-embed-data-dir...\u003e but was:\u003c...|92+|10s114ms|\u003d\u003d\u003d\u003d\u003d*[??title.features??]*[[An-embed-data-dir...\u003e\n\tat org.junit.Assert.assertEquals(Assert.java:115)\n\tat org.junit.Assert.assertEquals(Assert.java:144)\n\tat com.github.cukedoctor.bdd.CukedoctorMainSteps.A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(CukedoctorMainSteps.java:44)\n\tat ✽.Então A file named outputFile.adoc should be generated with the following content:(src/test/resources/features/cukedoctor_main.feature:95)\n",
+              "status": "failed"
+            },
+            "line": 95,
+            "name": "A file named outputFile.adoc should be generated with the following content:",
+            "match": {
+              "location": "CukedoctorMainSteps.A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(String)"
+            },
+            "keyword": "Então ",
+            "doc_string": {
+              "content_type": "",
+              "line": 96,
+              "value": " :toc: right\n:backend: html5\n:doctitle: Documentation\n:doctype: book\n:icons: font\n:sectanchors:\n:sectlink:\n:docinfo:\n:source-highlighter: highlightjs\n:toclevels: 3\n:hardbreaks:\n\n\u003d *Documentation*\n\n\u003d\u003d *Summary*\n[cols\u003d\"12*^m\", options\u003d\"header,footer\"]\n|\u003d\u003d\u003d\n3+|Scenarios 7+|Steps 2+|Features: 4\n\n|[green]#*Passed*#\n|[red]#*Failed*#\n|Total\n|[green]#*Passed*#\n|[red]#*Failed*#\n|[purple]#*Skipped*#\n|[maroon]#*Pending*#\n|[yellow]#*Undefined*#\n|[blue]#*Missing*#\n|Total\n|Duration\n|Status\n\n12+^|*\u003c\u003cAn-embed-data-directly-feature\u003e\u003e*\n|3\n|0\n|3\n|3\n|0\n|0\n|0\n|0\n|0\n|3\n|000ms\n|[green]#*passed*#\n\n12+^|*\u003c\u003cAn-outline-feature\u003e\u003e*\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|000ms\n|[green]#*passed*#\n\n12+^|*\u003c\u003cOne-passing-scenario-one-failing-scenario\u003e\u003e*\n|1\n|1\n|2\n|1\n|1\n|0\n|0\n|0\n|0\n|2\n|010ms\n|[red]#*failed*#\n\n12+^|*\u003c\u003cSample-test\u003e\u003e*\n|1\n|1\n|2\n|3\n|1\n|0\n|0\n|0\n|0\n|4\n|10s 104ms\n|[red]#*failed*#\n12+^|*Totals*\n|5|2|7|7|2|0|0|0|0|9 2+|10s 114ms\n|\u003d\u003d\u003d\n\n\u003d\u003d *Features*\n\n[[An-embed-data-directly-feature, An embed data directly feature]]\n\u003d\u003d\u003d *An embed data directly feature*\n\nminmax::An-embed-data-directly-feature[]\n\u003d\u003d\u003d\u003d Scenario: scenario 1\n****\nGiven ::\nI embed data directly icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(000ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario Outline: scenario 2\n****\nGiven ::\nI embed data directly icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(000ms)#\n****\n\n****\nGiven ::\nI embed data directly icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(000ms)#\n****\n\n[[An-outline-feature, An outline feature]]\n\u003d\u003d\u003d *An outline feature*\n\nminmax::An-outline-feature[]\n\u003d\u003d\u003d\u003d Scenario Outline: outline\n\n.examples1\n[cols\u003d\"1*\", options\u003d\"header\"]\n|\u003d\u003d\u003d\n|status\n|passes\n|fails\n|\u003d\u003d\u003d\n\n.examples2\n[cols\u003d\"1*\", options\u003d\"header\"]\n|\u003d\u003d\u003d\n|status\n|passes\n|\u003d\u003d\u003d\n\n[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing scenario]]\n\u003d\u003d\u003d *One passing scenario, one failing scenario*\n\nminmax::One-passing-scenario-one-failing-scenario[]\n\u003d\u003d\u003d\u003d Scenario: Passing\n[small]#tags: @a,@b#\n\n****\nGiven ::\nthis step passes icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(001ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario: Failing\n[small]#tags: @a,@c#\n\n****\nGiven ::\nthis step fails icon:thumbs-down[role\u003d\"red\",title\u003d\"Failed\"] [small right]#(008ms)#\n\nIMPORTANT:  (RuntimeError)\n./features/step_definitions/steps.rb:4:in /^this step fails$/\u0027\nfeatures/one_passing_one_failing.feature:10:in Given this step fails\u0027\n****\n\n[[Sample-test, Sample test]]\n\u003d\u003d\u003d *Sample test*\n\nminmax::Sample-test[]\n****\nAs a user  +\nI want to do something  +\nIn order to achieve another thing\n****\n\n\u003d\u003d\u003d\u003d Scenario Outline: Parsing scenarios with multiple examples\n\n.Example\n[cols\u003d\"2*\", options\u003d\"header\"]\n|\u003d\u003d\u003d\n|a\n|b\n|1\n|2\n|\u003d\u003d\u003d\n\n\u003d\u003d\u003d\u003d Scenario: Basic\n****\nGiven ::\nI navigate to the home page icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(044ms)#\nThen ::\nI see the text \u0027Home\u0027 icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(001ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario: Basic failure\n****\nGiven ::\nI navigate to the home page icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(040ms)#\nThen ::\nI see the text \u0027Hacienda\u0027 icon:thumbs-down[role\u003d\"red\",title\u003d\"Failed\"] [small right]#(10s 017ms)#\n\nIMPORTANT: expected to find text \"Hacienda\" in \"Home | Login Clinical Studies some engaging copy View Available Studies\" (RSpec::Expectations::ExpectationNotMetError)\n./features/step_definitions/study_admin_steps.rb:14:in `/^I see the text \u0027(.+)\u0027$/\u0027\nfeatures/test_outline.feature:15:in `Then I see the text \u0027Hacienda\u0027\u0027\n****"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "Cukedoctor Main",
+    "description": "As a user of CukedoctorMain\nI want to generate asciidoc files based on my cucumber test output\nSo that I can generate wonderful living documentation",
+    "id": "cukedoctor-main",
+    "keyword": "Funcionalidade",
+    "uri": "src/test/resources/features/cukedoctor_main.feature",
+    "tags": [
+      {
+        "name": "@language-pt"
+      }
+    ]
+  }
+]

--- a/cukedoctor-converter/src/test/resources/json-output/i18n/spanish_with_tag.json
+++ b/cukedoctor-converter/src/test/resources/json-output/i18n/spanish_with_tag.json
@@ -1,0 +1,147 @@
+[
+  {
+    "line": 3,
+    "elements": [
+      {
+        "line": 8,
+        "name": "Generate documentation of a single file",
+        "description": "",
+        "id": "cukedoctor-main;generate-documentation-of-a-single-file",
+        "type": "scenario",
+        "keyword": "Escenario",
+        "steps": [
+          {
+            "result": {
+              "duration": 139108176,
+              "status": "passed"
+            },
+            "line": 9,
+            "name": "A Cucumber json execution file is are already generated",
+            "match": {
+              "location": "CukedoctorMainSteps.A_Cucumber_json_execution_file_is_are_already_generated()"
+            },
+            "keyword": "Dado "
+          },
+          {
+            "result": {
+              "duration": 4658484718,
+              "status": "passed"
+            },
+            "line": 10,
+            "name": "I execute CukedoctorMain with args \"-o target/test-classes/outputFile.adoc\" \"-p target/test-classes/json-output/one_passing_one_failing.json\" and \"-t Documentation\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "-o target/test-classes/outputFile.adoc",
+                  "offset": 36
+                },
+                {
+                  "val": "-p target/test-classes/json-output/one_passing_one_failing.json",
+                  "offset": 77
+                },
+                {
+                  "val": "-t Documentation",
+                  "offset": 147
+                }
+              ],
+              "location": "CukedoctorMainSteps.I_execute_CukedoctorMain_with_args_and(String,String,String)"
+            },
+            "keyword": "Cuando "
+          },
+          {
+            "result": {
+              "duration": 2054294,
+              "status": "passed"
+            },
+            "line": 11,
+            "name": "A file named outputFile.adoc should be generated with the following content:",
+            "match": {
+              "location": "CukedoctorMainSteps.A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(String)"
+            },
+            "keyword": "Entonces ",
+            "doc_string": {
+              "content_type": "",
+              "line": 12,
+              "value": " :toc: right\n:backend: html5\n:doctitle: Documentation\n:doctype: book\n:icons: font\n:sectanchors:\n:sectlink:\n:docinfo:\n:source-highlighter: highlightjs\n:toclevels: 3\n:hardbreaks:\n\n\u003d *Documentation*\n\n\u003d\u003d *Summary*\n[cols\u003d\"12*^m\", options\u003d\"header,footer\"]\n|\u003d\u003d\u003d\n3+|Scenarios 7+|Steps 2+|Features: 1\n\n|[green]#*Passed*#\n|[red]#*Failed*#\n|Total\n|[green]#*Passed*#\n|[red]#*Failed*#\n|[purple]#*Skipped*#\n|[maroon]#*Pending*#\n|[yellow]#*Undefined*#\n|[blue]#*Missing*#\n|Total\n|Duration\n|Status\n\n12+^|*\u003c\u003cOne-passing-scenario-one-failing-scenario\u003e\u003e*\n|1\n|1\n|2\n|1\n|1\n|0\n|0\n|0\n|0\n|2\n|010ms\n|[red]#*failed*#\n12+^|*Totals*\n|1|1|2|1|1|0|0|0|0|2 2+|010ms\n|\u003d\u003d\u003d\n\n\u003d\u003d *Features*\n\n[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing scenario]]\n\u003d\u003d\u003d *One passing scenario, one failing scenario*\n\nminmax::One-passing-scenario-one-failing-scenario[]\n\u003d\u003d\u003d\u003d Scenario: Passing\n[small]#tags: @a,@b#\n\n****\nGiven ::\nthis step passes icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(001ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario: Failing\n[small]#tags: @a,@c#\n\n****\nGiven ::\nthis step fails icon:thumbs-down[role\u003d\"red\",title\u003d\"Failed\"] [small right]#(008ms)#\n\nIMPORTANT:  (RuntimeError)\n./features/step_definitions/steps.rb:4:in /^this step fails$/\u0027\nfeatures/one_passing_one_failing.feature:10:in Given this step fails\u0027\n****"
+            }
+          }
+        ]
+      },
+      {
+        "line": 92,
+        "name": "Generate documentation using multiple files",
+        "description": "",
+        "id": "cukedoctor-main;generate-documentation-using-multiple-files",
+        "type": "scenario",
+        "keyword": "Escenario",
+        "steps": [
+          {
+            "result": {
+              "duration": 34895,
+              "status": "passed"
+            },
+            "line": 93,
+            "name": "Cucumber multiple json execution files are already generate",
+            "match": {
+              "location": "CukedoctorMainSteps.Cucumber_multiple_json_execution_files_are_already_generate()"
+            },
+            "keyword": "Dado "
+          },
+          {
+            "result": {
+              "duration": 953666274,
+              "status": "passed"
+            },
+            "line": 94,
+            "name": "I execute CukedoctorMain with args \"-o target/test-classes/outputFile.adoc\" \"-p target/test-classes/json-output/\" and \"-t Documentation\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "-o target/test-classes/outputFile.adoc",
+                  "offset": 36
+                },
+                {
+                  "val": "-p target/test-classes/json-output/",
+                  "offset": 77
+                },
+                {
+                  "val": "-t Documentation",
+                  "offset": 119
+                }
+              ],
+              "location": "CukedoctorMainSteps.I_execute_CukedoctorMain_with_args_and(String,String,String)"
+            },
+            "keyword": "Cuando "
+          },
+          {
+            "result": {
+              "duration": 1723911,
+              "status": "passed"
+            },
+            "line": 95,
+            "name": "A file named outputFile.adoc should be generated with the following content:",
+            "match": {
+              "location": "CukedoctorMainSteps.A_file_named_outputFile_adoc_should_be_generated_with_the_following_content(String)"
+            },
+            "keyword": "Entonces ",
+            "doc_string": {
+              "content_type": "",
+              "line": 96,
+              "value": " :toc: right\n:backend: html5\n:doctitle: Documentation\n:doctype: book\n:icons: font\n:sectanchors:\n:sectlink:\n:docinfo:\n:source-highlighter: highlightjs\n:toclevels: 3\n:hardbreaks:\n\n\u003d *Documentation*\n\n\u003d\u003d *Summary*\n[cols\u003d\"12*^m\", options\u003d\"header,footer\"]\n|\u003d\u003d\u003d\n3+|Scenarios 7+|Steps 2+|Features: 4\n\n|[green]#*Passed*#\n|[red]#*Failed*#\n|Total\n|[green]#*Passed*#\n|[red]#*Failed*#\n|[purple]#*Skipped*#\n|[maroon]#*Pending*#\n|[yellow]#*Undefined*#\n|[blue]#*Missing*#\n|Total\n|Duration\n|Status\n\n12+^|*\u003c\u003cAn-embed-data-directly-feature\u003e\u003e*\n|3\n|0\n|3\n|3\n|0\n|0\n|0\n|0\n|0\n|3\n|000ms\n|[green]#*passed*#\n\n12+^|*\u003c\u003cAn-outline-feature\u003e\u003e*\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|0\n|000ms\n|[green]#*passed*#\n\n12+^|*\u003c\u003cOne-passing-scenario-one-failing-scenario\u003e\u003e*\n|1\n|1\n|2\n|1\n|1\n|0\n|0\n|0\n|0\n|2\n|010ms\n|[red]#*failed*#\n\n12+^|*\u003c\u003cSample-test\u003e\u003e*\n|1\n|1\n|2\n|3\n|1\n|0\n|0\n|0\n|0\n|4\n|10s 104ms\n|[red]#*failed*#\n12+^|*Totals*\n|5|2|7|7|2|0|0|0|0|9 2+|10s 114ms\n|\u003d\u003d\u003d\n\n\u003d\u003d *Features*\n\n[[An-embed-data-directly-feature, An embed data directly feature]]\n\u003d\u003d\u003d *An embed data directly feature*\n\nminmax::An-embed-data-directly-feature[]\n\u003d\u003d\u003d\u003d Scenario: scenario 1\n****\nGiven ::\nI embed data directly icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(000ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario Outline: scenario 2\n****\nGiven ::\nI embed data directly icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(000ms)#\n****\n\n****\nGiven ::\nI embed data directly icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(000ms)#\n****\n\n[[An-outline-feature, An outline feature]]\n\u003d\u003d\u003d *An outline feature*\n\nminmax::An-outline-feature[]\n\u003d\u003d\u003d\u003d Scenario Outline: outline\n\n.examples1\n[cols\u003d\"1*\", options\u003d\"header\"]\n|\u003d\u003d\u003d\n|status\n|passes\n|fails\n|\u003d\u003d\u003d\n\n.examples2\n[cols\u003d\"1*\", options\u003d\"header\"]\n|\u003d\u003d\u003d\n|status\n|passes\n|\u003d\u003d\u003d\n\n[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing scenario]]\n\u003d\u003d\u003d *One passing scenario, one failing scenario*\n\nminmax::One-passing-scenario-one-failing-scenario[]\n\u003d\u003d\u003d\u003d Scenario: Passing\n[small]#tags: @a,@b#\n\n****\nGiven ::\nthis step passes icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(001ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario: Failing\n[small]#tags: @a,@c#\n\n****\nGiven ::\nthis step fails icon:thumbs-down[role\u003d\"red\",title\u003d\"Failed\"] [small right]#(008ms)#\n\nIMPORTANT:  (RuntimeError)\n./features/step_definitions/steps.rb:4:in /^this step fails$/\u0027\nfeatures/one_passing_one_failing.feature:10:in Given this step fails\u0027\n****\n\n[[Sample-test, Sample test]]\n\u003d\u003d\u003d *Sample test*\n\nminmax::Sample-test[]\n****\nAs a user  +\nI want to do something  +\nIn order to achieve another thing\n****\n\n\u003d\u003d\u003d\u003d Scenario Outline: Parsing scenarios with multiple examples\n\n.Example\n[cols\u003d\"2*\", options\u003d\"header\"]\n|\u003d\u003d\u003d\n|a\n|b\n|1\n|2\n|\u003d\u003d\u003d\n\n\u003d\u003d\u003d\u003d Scenario: Basic\n****\nGiven ::\nI navigate to the home page icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(044ms)#\nThen ::\nI see the text \u0027Home\u0027 icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(001ms)#\n****\n\n\u003d\u003d\u003d\u003d Scenario: Basic failure\n****\nGiven ::\nI navigate to the home page icon:thumbs-up[role\u003d\"green\",title\u003d\"Passed\"] [small right]#(040ms)#\nThen ::\nI see the text \u0027Hacienda\u0027 icon:thumbs-down[role\u003d\"red\",title\u003d\"Failed\"] [small right]#(10s 017ms)#\n\nIMPORTANT: expected to find text \"Hacienda\" in \"Home | Login Clinical Studies some engaging copy View Available Studies\" (RSpec::Expectations::ExpectationNotMetError)\n./features/step_definitions/study_admin_steps.rb:14:in `/^I see the text \u0027(.+)\u0027$/\u0027\nfeatures/test_outline.feature:15:in `Then I see the text \u0027Hacienda\u0027\u0027\n****"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "Cukedoctor Main",
+    "description": "As a user of CukedoctorMain\nI want to generate asciidoc files based on my cucumber test output\nSo that I can generate wonderful living documentation",
+    "id": "cukedoctor-main",
+    "keyword": "Característica",
+    "uri": "src/test/resources/features/cukedoctor_main.feature",
+    "tags": [
+      {
+        "name": "@language-es"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Hi Raphaël,
since I'm using Cucumber 7, I have been facing the disappearance of the language feature.

This, because Cucumber decided to stop supporting comments in JSON files.
So now, language comments are not anymore properly set in JSON features and the i18n is not working.

This change aims at adding a tag @language-(en|es|fr|ge|pt), to mimic the behavior or ordering and allow users to update their Cucumber version.