### PR TITLE
Fix - Replace * keywords with their canonical form "And"

### DIFF
--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorStepsRenderer.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorStepsRenderer.java
@@ -32,13 +32,10 @@ import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/**
- * Created by pestano on 28/02/16.
- */
+/** Created by pestano on 28/02/16. */
 public class CukedoctorStepsRenderer extends AbstractBaseRenderer implements StepsRenderer {
 
-  public CukedoctorStepsRenderer() {
-  }
+  public CukedoctorStepsRenderer() {}
 
   public CukedoctorStepsRenderer(CukedoctorConfig cukedoctorConfig) {
     this.cukedoctorConfig = cukedoctorConfig;

--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorStepsRenderer.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorStepsRenderer.java
@@ -9,6 +9,7 @@ import static com.github.cukedoctor.util.Constants.Markup.listing;
 import static com.github.cukedoctor.util.Constants.Markup.table;
 import static com.github.cukedoctor.util.Constants.Markup.tableCol;
 import static com.github.cukedoctor.util.Constants.newLine;
+import static java.lang.Boolean.*;
 
 import com.github.cukedoctor.api.CukedoctorDocumentBuilder;
 import com.github.cukedoctor.api.model.Comment;
@@ -31,10 +32,13 @@ import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/** Created by pestano on 28/02/16. */
+/**
+ * Created by pestano on 28/02/16.
+ */
 public class CukedoctorStepsRenderer extends AbstractBaseRenderer implements StepsRenderer {
 
-  public CukedoctorStepsRenderer() {}
+  public CukedoctorStepsRenderer() {
+  }
 
   public CukedoctorStepsRenderer(CukedoctorConfig cukedoctorConfig) {
     this.cukedoctorConfig = cukedoctorConfig;
@@ -46,9 +50,9 @@ public class CukedoctorStepsRenderer extends AbstractBaseRenderer implements Ste
 
     docBuilder.textLine("==========");
     for (Step step : steps) {
-      docBuilder.append(step.getKeyword(), "::", newLine());
+      docBuilder.append(parseKeyword(step.getKeyword()), "::", newLine());
       docBuilder.append(step.getName() + " ", Status.getStatusIcon(step.getStatus()));
-      if (!cukedoctorConfig.isHideStepTime()) {
+      if (FALSE.equals(cukedoctorConfig.isHideStepTime())) {
         docBuilder.append(renderStepTime(step.getResult()));
       }
 
@@ -81,19 +85,29 @@ public class CukedoctorStepsRenderer extends AbstractBaseRenderer implements Ste
     return docBuilder.toString();
   }
 
+  private String parseKeyword(String keyword) {
+    return keyword.replace("*", "And");
+  }
+
   private boolean isDiscrete(Scenario scenario) {
-    if (!scenario.hasTags()) return false;
+    if (!scenario.hasTags()) {
+      return false;
+    }
     return isDiscrete(scenario.getTags());
   }
 
   private boolean isDiscrete(Feature feature) {
-    if (!feature.hasTags()) return false;
+    if (!feature.hasTags()) {
+      return false;
+    }
     return isDiscrete(feature.getTags());
   }
 
   private boolean isDiscrete(Iterable<Tag> tags) {
     for (Tag tag : tags) {
-      if (tag.isDiscrete()) return true;
+      if (tag.isDiscrete()) {
+        return true;
+      }
     }
 
     return false;

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/converter/CukedoctorConverterTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/converter/CukedoctorConverterTest.java
@@ -35,9 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Created by pestano on 02/06/15.
- */
+/** Created by pestano on 02/06/15. */
 @RunWith(JUnit4.class)
 public class CukedoctorConverterTest {
 
@@ -237,7 +235,8 @@ public class CukedoctorConverterTest {
 
     FileUtil.saveFile(
         "target/test-docs/doc_multiple_feature.adoc", resultDoc); // save to target/test-docs folder
-    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_FOR_MULTIPLE_FEATURES);
+    assertThat(resultDoc)
+        .isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_FOR_MULTIPLE_FEATURES);
   }
 
   @Test
@@ -273,7 +272,8 @@ public class CukedoctorConverterTest {
     FileUtil.saveFile(
         "target/test-docs/doc_without_features_sect.adoc",
         resultDoc); // save to target/test-docs folder
-    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_WITHOUT_FEATURES_SECTION);
+    assertThat(resultDoc)
+        .isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_WITHOUT_FEATURES_SECTION);
   }
 
   @Test
@@ -306,7 +306,9 @@ public class CukedoctorConverterTest {
     FileUtil.saveFile(
         "target/test-docs/doc_without_features_sect.adoc",
         resultDoc); // save to target/test-docs folder
-    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_WITHOUT_FEATURES_AND_SUMMARY_SECTIONS);
+    assertThat(resultDoc)
+        .isEqualToIgnoringWhitespace(
+            Expectations.DOCUMENTATION_WITHOUT_FEATURES_AND_SUMMARY_SECTIONS);
   }
 
   @Test
@@ -330,7 +332,8 @@ public class CukedoctorConverterTest {
     CukedoctorConverter converter = Cukedoctor.instance(features, attrs);
     converter.setFilename("target/living_documentation.adoc");
     String resultDoc = converter.renderDocumentation();
-    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_WITHOUT_SCENARIO_KEYWORD);
+    assertThat(resultDoc)
+        .isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_WITHOUT_SCENARIO_KEYWORD);
   }
 
   @Test
@@ -424,7 +427,8 @@ public class CukedoctorConverterTest {
     CukedoctorConverter converter = Cukedoctor.instance(features);
     converter.setFilename("target/living_documentation.adoc");
     String resultDoc = converter.renderDocumentation();
-    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_WITH_SCENARIO_WITHOUT_DESCRIPTION);
+    assertThat(resultDoc)
+        .isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_WITH_SCENARIO_WITHOUT_DESCRIPTION);
   }
 
   @Test
@@ -494,7 +498,8 @@ public class CukedoctorConverterTest {
         Cukedoctor.instance(
             features, GlobalConfig.getInstance().getDocumentAttributes().docTitle("Doc Title"));
     String resultDoc = converter.renderDocumentation();
-    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.FEATURE_WITH_STEP_TABLE_IN_PT_BR);
+    assertThat(resultDoc)
+        .isEqualToIgnoringWhitespace(Expectations.FEATURE_WITH_STEP_TABLE_IN_PT_BR);
   }
 
   @Test

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/converter/CukedoctorConverterTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/converter/CukedoctorConverterTest.java
@@ -3,6 +3,7 @@ package com.github.cukedoctor.converter;
 import static com.github.cukedoctor.extension.CukedoctorExtensionRegistry.DISABLE_ALL_EXT_KEY;
 import static com.github.cukedoctor.extension.CukedoctorExtensionRegistry.MINMAX_DISABLE_EXT_KEY;
 import static com.github.cukedoctor.renderer.Fixtures.embedDataDirectly;
+import static com.github.cukedoctor.renderer.Fixtures.featureWithAsterisk;
 import static com.github.cukedoctor.renderer.Fixtures.featureWithTableInStep;
 import static com.github.cukedoctor.renderer.Fixtures.invalidFeatureResult;
 import static com.github.cukedoctor.renderer.Fixtures.onePassingOneFailing;
@@ -10,6 +11,7 @@ import static com.github.cukedoctor.renderer.Fixtures.outline;
 import static com.github.cukedoctor.util.Constants.newLine;
 import static com.github.cukedoctor.util.Features.aFeatureWithTwoScenarios;
 import static com.github.cukedoctor.util.StringUtil.trimAllLines;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
@@ -24,6 +26,7 @@ import com.github.cukedoctor.parser.FeatureParser;
 import com.github.cukedoctor.util.Expectations;
 import com.github.cukedoctor.util.FileUtil;
 import java.io.File;
+import java.net.URL;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +35,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Created by pestano on 02/06/15. */
+/**
+ * Created by pestano on 02/06/15.
+ */
 @RunWith(JUnit4.class)
 public class CukedoctorConverterTest {
 
@@ -193,8 +198,7 @@ public class CukedoctorConverterTest {
 
     FileUtil.saveFile(
         "target/test-docs/doc_one_feature.adoc", resultDoc); // save to target/test-docs folder
-    assertThat(resultDoc.replaceAll("\r", ""))
-        .isEqualTo(Expectations.DOCUMENTATION_FOR_ONE_FEATURE.replaceAll("\r", ""));
+    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_FOR_ONE_FEATURE);
   }
 
   @Test
@@ -233,8 +237,7 @@ public class CukedoctorConverterTest {
 
     FileUtil.saveFile(
         "target/test-docs/doc_multiple_feature.adoc", resultDoc); // save to target/test-docs folder
-    assertThat(resultDoc.replaceAll("\r", ""))
-        .isEqualTo(Expectations.DOCUMENTATION_FOR_MULTIPLE_FEATURES.replaceAll("\r", ""));
+    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_FOR_MULTIPLE_FEATURES);
   }
 
   @Test
@@ -270,8 +273,7 @@ public class CukedoctorConverterTest {
     FileUtil.saveFile(
         "target/test-docs/doc_without_features_sect.adoc",
         resultDoc); // save to target/test-docs folder
-    assertThat(resultDoc.replaceAll("\r", ""))
-        .isEqualTo(Expectations.DOCUMENTATION_WITHOUT_FEATURES_SECTION.replaceAll("\r", ""));
+    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_WITHOUT_FEATURES_SECTION);
   }
 
   @Test
@@ -304,9 +306,7 @@ public class CukedoctorConverterTest {
     FileUtil.saveFile(
         "target/test-docs/doc_without_features_sect.adoc",
         resultDoc); // save to target/test-docs folder
-    assertThat(resultDoc.replaceAll("\r", ""))
-        .isEqualTo(
-            Expectations.DOCUMENTATION_WITHOUT_FEATURES_AND_SUMMARY_SECTIONS.replaceAll("\r", ""));
+    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_WITHOUT_FEATURES_AND_SUMMARY_SECTIONS);
   }
 
   @Test
@@ -330,8 +330,7 @@ public class CukedoctorConverterTest {
     CukedoctorConverter converter = Cukedoctor.instance(features, attrs);
     converter.setFilename("target/living_documentation.adoc");
     String resultDoc = converter.renderDocumentation();
-    assertThat(resultDoc.replaceAll("\r", ""))
-        .isEqualTo(Expectations.DOCUMENTATION_WITHOUT_SCENARIO_KEYWORD.replaceAll("\r", ""));
+    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_WITHOUT_SCENARIO_KEYWORD);
   }
 
   @Test
@@ -355,8 +354,7 @@ public class CukedoctorConverterTest {
     CukedoctorConverter converter = Cukedoctor.instance(features, attrs);
     converter.setFilename("target/living_documentation.adoc");
     String resultDoc = converter.renderDocumentation();
-    assertThat(resultDoc.replaceAll("\r", ""))
-        .isEqualTo(Expectations.DOCUMENTATION_WITHOUT_STEP_TIME.replaceAll("\r", ""));
+    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_WITHOUT_STEP_TIME);
   }
 
   @Test
@@ -381,8 +379,7 @@ public class CukedoctorConverterTest {
     CukedoctorConverter converter = Cukedoctor.instance(features, attrs);
     converter.setFilename("target/living_documentation.adoc");
     String resultDoc = converter.renderDocumentation();
-    assertThat(resultDoc.replaceAll("\r", ""))
-        .isEqualTo(Expectations.DOCUMENTATION_WITHOUT_TAGS.replaceAll("\r", ""));
+    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_WITHOUT_TAGS);
   }
 
   @Test
@@ -421,24 +418,13 @@ public class CukedoctorConverterTest {
 
   @Test
   public void shouldRenderDocumentationForScenariosWithoutDescription() {
-    List<Feature> features =
-        FeatureParser.parse(
-            getClass().getResource("/json-output/scenario_without_description.json").getPath());
+    URL featuresResource = getClass().getResource("/json-output/scenario_without_description.json");
+    List<Feature> features = FeatureParser.parse(requireNonNull(featuresResource).getPath());
 
     CukedoctorConverter converter = Cukedoctor.instance(features);
     converter.setFilename("target/living_documentation.adoc");
     String resultDoc = converter.renderDocumentation();
-    assertThat(resultDoc)
-        .isNotNull()
-        .containsOnlyOnce("= *Documentation*" + newLine())
-        .containsOnlyOnce("=== *Do something*" + newLine())
-        .containsOnlyOnce("==== Scenario: User browses to the site successfully" + newLine())
-        .containsOnlyOnce("User opens a browser")
-        .containsOnlyOnce("|1|0|1|1|0|0|0|0|0|1 2+|000ms");
-
-    assertThat(resultDoc.replaceAll("\r", ""))
-        .isEqualTo(
-            Expectations.DOCUMENTATION_WITH_SCENARIO_WITHOUT_DESCRIPTION.replaceAll("\r", ""));
+    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.DOCUMENTATION_WITH_SCENARIO_WITHOUT_DESCRIPTION);
   }
 
   @Test
@@ -508,7 +494,16 @@ public class CukedoctorConverterTest {
         Cukedoctor.instance(
             features, GlobalConfig.getInstance().getDocumentAttributes().docTitle("Doc Title"));
     String resultDoc = converter.renderDocumentation();
-    assertThat(resultDoc.replaceAll("\r", ""))
-        .isEqualTo(Expectations.FEATURE_WITH_STEP_TABLE_IN_PT_BR.replaceAll("\r", ""));
+    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.FEATURE_WITH_STEP_TABLE_IN_PT_BR);
+  }
+
+  @Test
+  public void shouldRenderFeatureWithAndReplacingAsterisks() {
+    List<Feature> features = FeatureParser.parse(featureWithAsterisk);
+    CukedoctorConverter converter =
+        Cukedoctor.instance(
+            features, GlobalConfig.getInstance().getDocumentAttributes().docTitle("Doc Title"));
+    String resultDoc = converter.renderDocumentation();
+    assertThat(resultDoc).isEqualToIgnoringWhitespace(Expectations.FEATURE_WITH_ASTERISK_REPLACED);
   }
 }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/parser/FeatureParserTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/parser/FeatureParserTest.java
@@ -185,7 +185,7 @@ public class FeatureParserTest {
   }
 
   @Test
-  public void shouldParseAndFindFeaturesInDirUsingAbsoluteath() {
+  public void shouldParseAndFindFeaturesInDirUsingAbsolutePath() {
     List<Feature> features =
         FeatureParser.findAndParse(
             Paths.get("").toAbsolutePath() + "/target/test-classes/json-output/parser");

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/parser/FeatureParserTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/parser/FeatureParserTest.java
@@ -244,8 +244,8 @@ public class FeatureParserTest {
 
   @Test
   public void shouldParseFeatureWithCommentsInScenariosExamples() {
-    URL featuresJson = getClass()
-        .getResource("/json-output/feature_with_comments_in_examples.json");
+    URL featuresJson =
+        getClass().getResource("/json-output/feature_with_comments_in_examples.json");
     List<Feature> features = FeatureParser.parse(requireNonNull(featuresJson).getPath());
     assertThat(features).isNotNull().hasSize(1);
   }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/parser/FeatureParserTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/parser/FeatureParserTest.java
@@ -1,5 +1,6 @@
 package com.github.cukedoctor.parser;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -40,7 +41,7 @@ public class FeatureParserTest {
   @Test
   public void shouldParseFeatureUsingResourcePath() {
     URL featureFile = getClass().getResource("/json-output/" + onePassingOneFailing);
-    String path = FileUtil.findJsonFile(featureFile.getPath());
+    String path = FileUtil.findJsonFile(requireNonNull(featureFile).getPath());
     List<Feature> features = FeatureParser.parse(path);
     assertThat(features)
         .isNotNull()
@@ -243,11 +244,9 @@ public class FeatureParserTest {
 
   @Test
   public void shouldParseFeatureWithCommentsInScenariosExamples() {
-    List<Feature> features =
-        FeatureParser.parse(
-            getClass()
-                .getResource("/json-output/feature_with_comments_in_examples.json")
-                .getPath());
+    URL featuresJson = getClass()
+        .getResource("/json-output/feature_with_comments_in_examples.json");
+    List<Feature> features = FeatureParser.parse(requireNonNull(featuresJson).getPath());
     assertThat(features).isNotNull().hasSize(1);
   }
 }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/renderer/Fixtures.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/renderer/Fixtures.java
@@ -9,6 +9,7 @@ public class Fixtures {
   public static final String invalidFeatureResult;
   public static final String featureWithTableInStep;
   public static final String featureWithSourceDocStringInStep;
+  public static final String featureWithAsterisk;
 
   static {
     onePassingOneFailing =
@@ -22,5 +23,7 @@ public class Fixtures {
         FileUtil.findJsonFile("target/test-classes/json-output/step-with-table.json");
     featureWithSourceDocStringInStep =
         FileUtil.findJsonFile("target/test-classes/json-output/step-with-source-doc-string.json");
+    featureWithAsterisk =
+        FileUtil.findJsonFile("target/test-classes/json-output/feature_with_asterisk.json");
   }
 }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/util/Expectations.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/util/Expectations.java
@@ -3,7 +3,9 @@ package com.github.cukedoctor.util;
 import static com.github.cukedoctor.util.Constants.home;
 import static com.github.cukedoctor.util.Constants.newLine;
 
-/** Created by pestano on 07/06/15. */
+/**
+ * Created by pestano on 07/06/15.
+ */
 public interface Expectations {
 
   String SUMMARY_FOR_ONE_FEATURE =
@@ -1267,168 +1269,6 @@ public interface Expectations {
           + newLine()
           + "";
 
-  String FEATURE_WITH_STEP_TABLE =
-      ":toc: right"
-          + newLine()
-          + ":backend: html5"
-          + newLine()
-          + ":doctitle: Doc Title"
-          + newLine()
-          + ":doctype: book"
-          + newLine()
-          + ":icons: font"
-          + newLine()
-          + ":sectanchors:"
-          + newLine()
-          + ":sectlink:"
-          + newLine()
-          + ":docinfo:"
-          + newLine()
-          + ":source-highlighter: highlightjs:toclevels: 3\n:hardbreaks:"
-          + newLine()
-          + ""
-          + newLine()
-          + "= *Doc Title*"
-          + newLine()
-          + ""
-          + newLine()
-          + "== *Summary*"
-          + newLine()
-          + "[cols=\"12*^m\", options=\"header,footer\"]"
-          + newLine()
-          + "|==="
-          + newLine()
-          + "3+|Scenarios 7+|Steps 2+|Features: 1"
-          + newLine()
-          + ""
-          + newLine()
-          + "|[green]#*Passed*#"
-          + newLine()
-          + "|[red]#*Failed*#"
-          + newLine()
-          + "|Total"
-          + newLine()
-          + "|[green]#*Passed*#"
-          + newLine()
-          + "|[red]#*Failed*#"
-          + newLine()
-          + "|[purple]#*Skipped*#"
-          + newLine()
-          + "|[maroon]#*Pending*#"
-          + newLine()
-          + "|[yellow]#*Undefined*#"
-          + newLine()
-          + "|[blue]#*Missing*#"
-          + newLine()
-          + "|Total"
-          + newLine()
-          + "|Duration"
-          + newLine()
-          + "|Status"
-          + newLine()
-          + ""
-          + newLine()
-          + "12+^|*<<Search>>*"
-          + newLine()
-          + "|1"
-          + newLine()
-          + "|0"
-          + newLine()
-          + "|1"
-          + newLine()
-          + "|1"
-          + newLine()
-          + "|0"
-          + newLine()
-          + "|0"
-          + newLine()
-          + "|0"
-          + newLine()
-          + "|0"
-          + newLine()
-          + "|0"
-          + newLine()
-          + "|1"
-          + newLine()
-          + "|111ms"
-          + newLine()
-          + "|[green]#*passed*#"
-          + newLine()
-          + "12+^|*Totals*"
-          + newLine()
-          + "|1|0|1|1|0|0|0|0|0|1 2+|111ms"
-          + newLine()
-          + "|==="
-          + newLine()
-          + ""
-          + newLine()
-          + "== *Features*"
-          + newLine()
-          + ""
-          + newLine()
-          + "[[Search, Search]]"
-          + newLine()
-          + "=== *Search*"
-          + newLine()
-          + ""
-          + newLine()
-          + "minmax::Search[]"
-          + newLine()
-          + "==== Cenario: Find messages by content"
-          + newLine()
-          + "[small]#tags: @txn#"
-          + newLine()
-          + ""
-          + newLine()
-          + newLine()
-          + "=========="
-          + newLine()
-          + "Dado ::"
-          + newLine()
-          + Constants.Markup.exampleBlock()
-          + newLine()
-          + "a User has posted the following messages:"
-          + " icon:thumbs-up[role=\"green\",title=\"Passed\"] [small right]#(111ms)#"
-          + newLine()
-          + ""
-          + newLine()
-          + "[cols=\"1*\", options=\"header\"]"
-          + newLine()
-          + "|==="
-          + newLine()
-          + "|content"
-          + newLine()
-          + "|I am making dinner"
-          + newLine()
-          + "|I just woke up"
-          + newLine()
-          + "|I am going to work"
-          + newLine()
-          + "|==="
-          + newLine()
-          + ""
-          + newLine()
-          + "----"
-          + newLine()
-          + ""
-          + newLine()
-          + "--"
-          + newLine()
-          + "A paragraph in an open block."
-          + newLine()
-          + "--"
-          + newLine()
-          + ""
-          + newLine()
-          + "----"
-          + newLine()
-          + Constants.Markup.exampleBlock()
-          + newLine()
-          + "=========="
-          + newLine()
-          + ""
-          + newLine();
-
   String FEATURE_WITH_STEP_TABLE_IN_PT_BR =
       ":toc: right"
           + newLine()
@@ -1765,5 +1605,169 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
+          + newLine();
+
+  String FEATURE_WITH_ASTERISK_REPLACED =
+      ":toc: right"
+          + newLine()
+          + ":backend: html5"
+          + newLine()
+          + ":doctitle: Doc Title"
+          + newLine()
+          + ":doctype: book"
+          + newLine()
+          + ":icons: font"
+          + newLine()
+          + ":sectanchors:"
+          + newLine()
+          + ":sectlink:"
+          + newLine()
+          + ":docinfo:"
+          + newLine()
+          + ":source-highlighter: highlightjs"
+          + newLine()
+          + ":toclevels: 3"
+          + newLine()
+          + ":hardbreaks:"
+          + newLine()
+          + ":chapter-label: Chapter"
+          + newLine()
+          + ":version-label: Version"
+          + newLine()
+          + ""
+          + newLine()
+          + "= *Doc Title*"
+          + newLine()
+          + ""
+          + newLine()
+          + "include::"
+          + home()
+          + "cukedoctor-intro.adoc[leveloffset=+1]"
+          + newLine()
+          + ""
+          + newLine()
+          + "== *Summary*"
+          + newLine()
+          + "[cols=\"12*^m\", options=\"header,footer\"]"
+          + newLine()
+          + "|==="
+          + newLine()
+          + "3+|Scenarios 7+|Steps 2+|Features: 1"
+          + newLine()
+          + ""
+          + newLine()
+          + "|[green]#*Passed*#"
+          + newLine()
+          + "|[red]#*Failed*#"
+          + newLine()
+          + "|Total"
+          + newLine()
+          + "|[green]#*Passed*#"
+          + newLine()
+          + "|[red]#*Failed*#"
+          + newLine()
+          + "|[purple]#*Skipped*#"
+          + newLine()
+          + "|[maroon]#*Pending*#"
+          + newLine()
+          + "|[yellow]#*Undefined*#"
+          + newLine()
+          + "|[blue]#*Missing*#"
+          + newLine()
+          + "|Total"
+          + newLine()
+          + "|Duration"
+          + newLine()
+          + "|Status"
+          + newLine()
+          + ""
+          + newLine()
+          + "12+^|*<<Echoing-a-message>>*"
+          + newLine()
+          + "|1"
+          + newLine()
+          + "|0"
+          + newLine()
+          + "|1"
+          + newLine()
+          + "|4"
+          + newLine()
+          + "|0"
+          + newLine()
+          + "|0"
+          + newLine()
+          + "|0"
+          + newLine()
+          + "|0"
+          + newLine()
+          + "|0"
+          + newLine()
+          + "|4"
+          + newLine()
+          + "|025ms"
+          + newLine()
+          + "|[green]#*passed*#"
+          + newLine()
+          + "12+^|*Totals*"
+          + newLine()
+          + "|1|0|1|4|0|0|0|0|0|4 2+|025ms"
+          + newLine()
+          + "|==="
+          + newLine()
+          + ""
+          + newLine()
+          + "== *Features*"
+          + newLine()
+          + ""
+          + newLine()
+          + "[[Echoing-a-message, Echoing a message]]"
+          + newLine()
+          + "=== *Echoing a message*"
+          + newLine()
+          + ""
+          + newLine()
+          + "ifndef::backend-pdf[]"
+          + newLine()
+          + "minmax::Echoing-a-message[]"
+          + newLine()
+          + "endif::[]"
+          + newLine()
+          + "****"
+          + newLine()
+          + "As a user"
+          + newLine()
+          + "I want an echo service"
+          + newLine()
+          + "So I can play with Spring"
+          + newLine()
+          + "****"
+          + newLine()
+          + ""
+          + newLine()
+          + "==== Scenario: Receive an echo of a message sent through the API"
+          + newLine()
+          + ""
+          + newLine()
+          + "=========="
+          + newLine()
+          + "Given ::"
+          + newLine()
+          + "application is up icon:thumbs-up[role=\"green\",title=\"Passed\"] [small right]#(003ms)#"
+          + newLine()
+          + "And ::"
+          + newLine()
+          + "today is 2022-08-14 icon:thumbs-up[role=\"green\",title=\"Passed\"] [small right]#(010ms)#"
+          + newLine()
+          + "When ::"
+          + newLine()
+          + "I send a message \"Hello\" icon:thumbs-up[role=\"green\",title=\"Passed\"] [small right]#(009ms)#"
+          + newLine()
+          + "Then ::"
+          + newLine()
+          + "API replies \"[2022-08-14] echo <Hello>\" icon:thumbs-up[role=\"green\",title=\"Passed\"] [small right]#(000ms)#"
+          + newLine()
+          + "=========="
+          + newLine()
+          + ""
           + newLine();
 }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/util/Expectations.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/util/Expectations.java
@@ -3,9 +3,7 @@ package com.github.cukedoctor.util;
 import static com.github.cukedoctor.util.Constants.home;
 import static com.github.cukedoctor.util.Constants.newLine;
 
-/**
- * Created by pestano on 07/06/15.
- */
+/** Created by pestano on 07/06/15. */
 public interface Expectations {
 
   String SUMMARY_FOR_ONE_FEATURE =
@@ -1752,19 +1750,23 @@ public interface Expectations {
           + newLine()
           + "Given ::"
           + newLine()
-          + "application is up icon:thumbs-up[role=\"green\",title=\"Passed\"] [small right]#(003ms)#"
+          + "application is up icon:thumbs-up[role=\"green\",title=\"Passed\"] [small"
+          + " right]#(003ms)#"
           + newLine()
           + "And ::"
           + newLine()
-          + "today is 2022-08-14 icon:thumbs-up[role=\"green\",title=\"Passed\"] [small right]#(010ms)#"
+          + "today is 2022-08-14 icon:thumbs-up[role=\"green\",title=\"Passed\"] [small"
+          + " right]#(010ms)#"
           + newLine()
           + "When ::"
           + newLine()
-          + "I send a message \"Hello\" icon:thumbs-up[role=\"green\",title=\"Passed\"] [small right]#(009ms)#"
+          + "I send a message \"Hello\" icon:thumbs-up[role=\"green\",title=\"Passed\"] [small"
+          + " right]#(009ms)#"
           + newLine()
           + "Then ::"
           + newLine()
-          + "API replies \"[2022-08-14] echo <Hello>\" icon:thumbs-up[role=\"green\",title=\"Passed\"] [small right]#(000ms)#"
+          + "API replies \"[2022-08-14] echo <Hello>\""
+          + " icon:thumbs-up[role=\"green\",title=\"Passed\"] [small right]#(000ms)#"
           + newLine()
           + "=========="
           + newLine()

--- a/cukedoctor-converter/src/test/resources/json-output/feature_with_asterisk.json
+++ b/cukedoctor-converter/src/test/resources/json-output/feature_with_asterisk.json
@@ -1,0 +1,119 @@
+[
+  {
+    "line": 1,
+    "elements": [
+      {
+        "start_timestamp": "2022-08-14T15:36:35.674Z",
+        "before": [
+          {
+            "result": {
+              "duration": 232000,
+              "status": "passed"
+            },
+            "match": {
+              "location": "org.rdlopes.demo.bdd.steps.DemoSteps.before(io.cucumber.java.Scenario)"
+            }
+          }
+        ],
+        "line": 7,
+        "name": "Receive an echo of a message sent through the API",
+        "description": "",
+        "id": "echoing-a-message;receive-an-echo-of-a-message-sent-through-the-api",
+        "after": [
+          {
+            "embeddings": [
+              {
+                "data": "WyVoZWFkZXIsIGNvbHM9IjEsMSJdCnw9PT0KfFNldCB1cHxEb25lfEV4cGVjdGVkCnxudWxsfG51bGx8bnVsbAp8PT09Cg==",
+                "mime_type": "text/asciidoc",
+                "name": "Summary"
+              }
+            ],
+            "result": {
+              "duration": 211000,
+              "status": "passed"
+            },
+            "match": {
+              "location": "org.rdlopes.demo.bdd.steps.DemoSteps.after(io.cucumber.java.Scenario)"
+            }
+          }
+        ],
+        "type": "scenario",
+        "keyword": "Scenario",
+        "steps": [
+          {
+            "result": {
+              "duration": 3942000,
+              "status": "passed"
+            },
+            "line": 8,
+            "name": "application is up",
+            "match": {
+              "location": "org.rdlopes.demo.bdd.steps.ActuatorSteps.applicationIsUp()"
+            },
+            "keyword": "Given "
+          },
+          {
+            "result": {
+              "duration": 10611000,
+              "status": "passed"
+            },
+            "line": 9,
+            "name": "today is 2022-08-14",
+            "match": {
+              "arguments": [
+                {
+                  "val": "2022-08-14",
+                  "offset": 9
+                }
+              ],
+              "location": "org.rdlopes.demo.bdd.steps.DemoSteps.todayIs(java.time.LocalDate)"
+            },
+            "keyword": "* "
+          },
+          {
+            "result": {
+              "duration": 9540000,
+              "status": "passed"
+            },
+            "line": 10,
+            "name": "I send a message \"Hello\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "\"Hello\"",
+                  "offset": 17
+                }
+              ],
+              "location": "org.rdlopes.demo.bdd.steps.RestSteps.iSendAMessage(java.lang.String)"
+            },
+            "keyword": "When "
+          },
+          {
+            "result": {
+              "duration": 981000,
+              "status": "passed"
+            },
+            "line": 11,
+            "name": "API replies \"[2022-08-14] echo <Hello>\"",
+            "match": {
+              "arguments": [
+                {
+                  "val": "\"[2022-08-14] echo <Hello>\"",
+                  "offset": 12
+                }
+              ],
+              "location": "org.rdlopes.demo.bdd.steps.RestSteps.apiReplies(java.lang.String)"
+            },
+            "keyword": "Then "
+          }
+        ]
+      }
+    ],
+    "name": "Echoing a message",
+    "description": "  As a user\n  I want an echo service\n  So I can play with Spring",
+    "id": "echoing-a-message",
+    "keyword": "Feature",
+    "uri": "classpath:features/01_echo.feature",
+    "tags": []
+  }
+]


### PR DESCRIPTION
This fix closes #277 by replacing * keyword placeholders in converter.