### PR TITLE
fix: logging non existing order should be debug

### DIFF
--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Feature.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/api/model/Feature.java
@@ -295,7 +295,7 @@ public class Feature implements Comparable<Feature> {
     try {
       return Integer.parseInt(orderAsString);
     } catch (Exception e) {
-      log.warn(
+      log.debug(
           "Could not get order of feature {} from {} cause: {}",
           name,
           orderAsString,


### PR DESCRIPTION
This PR closes #279 by setting the log level of order not found to debug.