### PR TITLE
fix: ignore quote in summary reference ids

### DIFF
--- a/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorSummaryRenderer.java
+++ b/cukedoctor-converter/src/main/java/com/github/cukedoctor/renderer/CukedoctorSummaryRenderer.java
@@ -1,5 +1,6 @@
 package com.github.cukedoctor.renderer;
 
+import static com.github.cukedoctor.util.Assert.*;
 import static com.github.cukedoctor.util.Constants.Markup.bold;
 import static com.github.cukedoctor.util.Constants.Markup.h2;
 import static com.github.cukedoctor.util.Constants.Markup.table;
@@ -94,13 +95,7 @@ public class CukedoctorSummaryRenderer extends AbstractBaseRenderer implements S
     for (Feature feature : features) {
       // TODO convert to AsciidocMarkupBuilder
       docBuilder.append(
-          newLine(),
-          "12+^",
-          tableCol(),
-          "*<<",
-          feature.getName().replace(",", "").replace(" ", "-"),
-          ">>*",
-          newLine());
+          newLine(), "12+^", tableCol(), "*", renderFeatureReferenceId(feature), "*", newLine());
       StepResults stepResults = feature.getStepResults();
       ScenarioResults scenarioResults = feature.getScenarioResults();
 
@@ -160,5 +155,17 @@ public class CukedoctorSummaryRenderer extends AbstractBaseRenderer implements S
             tableCol(),
             Formatter.formatTime(scenarioTotalizationsCache.getTotalDuration()));
     docBuilder.newLine();
+  }
+
+  protected String renderFeatureId(Feature feature) {
+    // Anchor must not have blanks neither commas to work
+    return feature.getName().replace(",", "").replace("'", "-").replace(" ", "-");
+  }
+
+  protected String renderFeatureReferenceId(Feature feature) {
+    if (isNull(feature) || not(hasText(feature.getName()))) {
+      return "";
+    }
+    return "<<" + renderFeatureId(feature) + "," + feature.getName() + ">>";
   }
 }

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/converter/CukedoctorConverterTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/converter/CukedoctorConverterTest.java
@@ -189,7 +189,9 @@ public class CukedoctorConverterTest {
         .containsOnlyOnce(":doctype: book" + newLine())
         .containsOnlyOnce(":toc: left" + newLine())
         .containsOnlyOnce("= *Living Documentation*" + newLine())
-        .containsOnlyOnce("<<One-passing-scenario-one-failing-scenario>>")
+        .containsOnlyOnce(
+            "<<One-passing-scenario-one-failing-scenario,One passing scenario, one failing"
+                + " scenario>>")
         .containsOnlyOnce("|[red]#*failed*#")
         .contains("|010ms")
         .containsOnlyOnce("|1|1|2|1|1|0|0|0|0|2 2+|010ms");
@@ -224,9 +226,11 @@ public class CukedoctorConverterTest {
         .containsOnlyOnce(":doctype: book" + newLine())
         .containsOnlyOnce(":toc: left" + newLine())
         .contains("= *Living Documentation*" + newLine())
-        .containsOnlyOnce("<<One-passing-scenario-one-failing-scenario>>")
-        .containsOnlyOnce("<<An-embed-data-directly-feature>>")
-        .containsOnlyOnce("<<An-outline-feature>>")
+        .containsOnlyOnce(
+            "<<One-passing-scenario-one-failing-scenario,One passing scenario, one failing"
+                + " scenario>>")
+        .containsOnlyOnce("<<An-embed-data-directly-feature,An embed data directly feature>>")
+        .containsOnlyOnce("<<An-outline-feature,An outline feature>>")
         .doesNotContain("<<invalid-feature-result*>>")
         .contains("|[green]#*passed*#")
         .containsOnlyOnce("|[red]#*failed*#")
@@ -264,7 +268,9 @@ public class CukedoctorConverterTest {
         .containsOnlyOnce(":doctype: book" + newLine())
         .containsOnlyOnce(":toc: left" + newLine())
         .containsOnlyOnce("= *Living Documentation*" + newLine())
-        .containsOnlyOnce("<<One-passing-scenario-one-failing-scenario>>")
+        .containsOnlyOnce(
+            "<<One-passing-scenario-one-failing-scenario,One passing scenario, one failing"
+                + " scenario>>")
         .containsOnlyOnce("|[red]#*failed*#")
         .contains("|010ms")
         .containsOnlyOnce("|1|1|2|1|1|0|0|0|0|2 2+|010ms");
@@ -301,7 +307,9 @@ public class CukedoctorConverterTest {
         .containsOnlyOnce(":doctype: book" + newLine())
         .containsOnlyOnce(":toc: left" + newLine())
         .containsOnlyOnce("= *Living Documentation*" + newLine())
-        .doesNotContain("<<One-passing-scenario-one-failing-scenario>>");
+        .doesNotContain(
+            "<<One-passing-scenario-one-failing-scenario,One passing scenario, one failing"
+                + " scenario>>");
 
     FileUtil.saveFile(
         "target/test-docs/doc_without_features_sect.adoc",

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/renderer/CukedoctorSummaryRendererTest.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/renderer/CukedoctorSummaryRendererTest.java
@@ -1,9 +1,6 @@
 package com.github.cukedoctor.renderer;
 
-import static com.github.cukedoctor.renderer.Fixtures.embedDataDirectly;
-import static com.github.cukedoctor.renderer.Fixtures.invalidFeatureResult;
-import static com.github.cukedoctor.renderer.Fixtures.onePassingOneFailing;
-import static com.github.cukedoctor.renderer.Fixtures.outline;
+import static com.github.cukedoctor.renderer.Fixtures.*;
 import static com.github.cukedoctor.util.Constants.newLine;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,6 +10,7 @@ import com.github.cukedoctor.parser.FeatureParser;
 import com.github.cukedoctor.spi.SummaryRenderer;
 import com.github.cukedoctor.util.Expectations;
 import java.util.List;
+import java.util.Objects;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -42,13 +40,15 @@ public class CukedoctorSummaryRendererTest {
   public void shouldRenderSummaryForFeatureWithBackground() {
     List<Feature> features =
         FeatureParser.parse(
-            getClass().getResource("/json-output/feature_with_background.json").getPath());
+            Objects.requireNonNull(
+                    getClass().getResource("/json-output/feature_with_background.json"))
+                .getPath());
     String resultDoc =
         new CukedoctorSummaryRenderer()
             .renderSummary(features, CukedoctorDocumentBuilder.Factory.newInstance());
     assertThat(resultDoc)
         .isNotNull()
-        .containsOnlyOnce("<<A-feature-with-background>>")
+        .containsOnlyOnce("<<A-feature-with-background,A feature with background>>")
         .contains("*Totals*" + newLine() + "|2|0|2|4|0|0|0|0|0|4");
   }
 

--- a/cukedoctor-converter/src/test/java/com/github/cukedoctor/util/Expectations.java
+++ b/cukedoctor-converter/src/test/java/com/github/cukedoctor/util/Expectations.java
@@ -15,7 +15,6 @@ public interface Expectations {
           + newLine()
           + "3+|Scenarios 7+|Steps 2+|Features: 1"
           + newLine()
-          + ""
           + newLine()
           + "|[green]#*Passed*#"
           + newLine()
@@ -41,9 +40,9 @@ public interface Expectations {
           + newLine()
           + "|Status"
           + newLine()
-          + ""
           + newLine()
-          + "12+^|*<<One-passing-scenario-one-failing-scenario>>*"
+          + "12+^|*<<One-passing-scenario-one-failing-scenario,One passing scenario, one failing"
+          + " scenario>>*"
           + newLine()
           + "|1"
           + newLine()
@@ -85,7 +84,6 @@ public interface Expectations {
           + newLine()
           + "3+|Scenarios 7+|Steps 2+|Features: 3"
           + newLine()
-          + ""
           + newLine()
           + "|[green]#*Passed*#"
           + newLine()
@@ -111,9 +109,8 @@ public interface Expectations {
           + newLine()
           + "|Status"
           + newLine()
-          + ""
           + newLine()
-          + "12+^|*<<An-embed-data-directly-feature>>*"
+          + "12+^|*<<An-embed-data-directly-feature,An embed data directly feature>>*"
           + newLine()
           + "|3"
           + newLine()
@@ -139,9 +136,8 @@ public interface Expectations {
           + newLine()
           + "|[green]#*passed*#"
           + newLine()
-          + ""
           + newLine()
-          + "12+^|*<<An-outline-feature>>*"
+          + "12+^|*<<An-outline-feature,An outline feature>>*"
           + newLine()
           + "|0"
           + newLine()
@@ -167,9 +163,9 @@ public interface Expectations {
           + newLine()
           + "|[green]#*passed*#"
           + newLine()
-          + ""
           + newLine()
-          + "12+^|*<<One-passing-scenario-one-failing-scenario>>*"
+          + "12+^|*<<One-passing-scenario-one-failing-scenario,One passing scenario, one failing"
+          + " scenario>>*"
           + newLine()
           + "|1"
           + newLine()
@@ -229,17 +225,14 @@ public interface Expectations {
           + newLine()
           + ":version-label: Version"
           + newLine()
-          + ""
           + newLine()
           + "= *Living Documentation*"
           + newLine()
-          + ""
           + newLine()
           + "include::"
           + home()
           + "cukedoctor-intro.adoc[leveloffset=+1]"
           + newLine()
-          + ""
           + newLine()
           + "== *Summary*"
           + newLine()
@@ -249,7 +242,6 @@ public interface Expectations {
           + newLine()
           + "3+|Scenarios 7+|Steps 2+|Features: 1"
           + newLine()
-          + ""
           + newLine()
           + "|[green]#*Passed*#"
           + newLine()
@@ -275,9 +267,9 @@ public interface Expectations {
           + newLine()
           + "|Status"
           + newLine()
-          + ""
           + newLine()
-          + "12+^|*<<One-passing-scenario-one-failing-scenario>>*"
+          + "12+^|*<<One-passing-scenario-one-failing-scenario,One passing scenario, one failing"
+          + " scenario>>*"
           + newLine()
           + "|1"
           + newLine()
@@ -309,18 +301,15 @@ public interface Expectations {
           + newLine()
           + "|==="
           + newLine()
-          + ""
           + newLine()
           + "== *Features*"
           + newLine()
-          + ""
           + newLine()
           + "[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing"
           + " scenario]]"
           + newLine()
           + "=== *One passing scenario, one failing scenario*"
           + newLine()
-          + ""
           + newLine()
           + "ifndef::backend-pdf[]"
           + newLine()
@@ -332,9 +321,7 @@ public interface Expectations {
           + newLine()
           + "[small]#tags: @a,@b#"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -345,15 +332,12 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
           + newLine()
           + "==== Scenario: Failing icon:thumbs-down[role=\"red\",title=\"Failed\"]"
           + newLine()
           + "[small]#tags: @a,@c#"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -361,7 +345,6 @@ public interface Expectations {
           + newLine()
           + "this step fails icon:thumbs-down[role=\"red\",title=\"Failed\"] [small right]#(008ms)#"
           + newLine()
-          + ""
           + newLine()
           + "IMPORTANT:  (RuntimeError)"
           + newLine()
@@ -371,9 +354,7 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
-          + newLine()
-          + "";
+          + newLine();
 
   String DOCUMENTATION_WITHOUT_FEATURES_SECTION =
       ":toc: left"
@@ -402,17 +383,14 @@ public interface Expectations {
           + newLine()
           + ":version-label: Version"
           + newLine()
-          + ""
           + newLine()
           + "= *Living Documentation*"
           + newLine()
-          + ""
           + newLine()
           + "include::"
           + home()
           + "cukedoctor-intro.adoc[leveloffset=+1]"
           + newLine()
-          + ""
           + newLine()
           + "== *Summary*"
           + newLine()
@@ -422,7 +400,6 @@ public interface Expectations {
           + newLine()
           + "3+|Scenarios 7+|Steps 2+|Features: 1"
           + newLine()
-          + ""
           + newLine()
           + "|[green]#*Passed*#"
           + newLine()
@@ -448,9 +425,9 @@ public interface Expectations {
           + newLine()
           + "|Status"
           + newLine()
-          + ""
           + newLine()
-          + "12+^|*<<One-passing-scenario-one-failing-scenario>>*"
+          + "12+^|*<<One-passing-scenario-one-failing-scenario,One passing scenario, one failing"
+          + " scenario>>*"
           + newLine()
           + "|1"
           + newLine()
@@ -482,14 +459,12 @@ public interface Expectations {
           + newLine()
           + "|==="
           + newLine()
-          + ""
           + newLine()
           + "[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing"
           + " scenario]]"
           + newLine()
           + "== *One passing scenario, one failing scenario*"
           + newLine()
-          + ""
           + newLine()
           + "ifndef::backend-pdf[]"
           + newLine()
@@ -501,9 +476,7 @@ public interface Expectations {
           + newLine()
           + "[small]#tags: @a,@b#"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -514,15 +487,12 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
           + newLine()
           + "=== Scenario: Failing icon:thumbs-down[role=\"red\",title=\"Failed\"]"
           + newLine()
           + "[small]#tags: @a,@c#"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -530,7 +500,6 @@ public interface Expectations {
           + newLine()
           + "this step fails icon:thumbs-down[role=\"red\",title=\"Failed\"] [small right]#(008ms)#"
           + newLine()
-          + ""
           + newLine()
           + "IMPORTANT:  (RuntimeError)"
           + newLine()
@@ -540,9 +509,7 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
-          + newLine()
-          + "";
+          + newLine();
 
   String DOCUMENTATION_WITHOUT_FEATURES_AND_SUMMARY_SECTIONS =
       ":toc: left"
@@ -571,11 +538,9 @@ public interface Expectations {
           + newLine()
           + ":version-label: Version"
           + newLine()
-          + ""
           + newLine()
           + "= *Living Documentation*"
           + newLine()
-          + ""
           + newLine()
           + "include::"
           + home()
@@ -588,7 +553,6 @@ public interface Expectations {
           + newLine()
           + "== *One passing scenario, one failing scenario*"
           + newLine()
-          + ""
           + newLine()
           + "ifndef::backend-pdf[]"
           + newLine()
@@ -600,9 +564,7 @@ public interface Expectations {
           + newLine()
           + "[small]#tags: @a,@b#"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -613,15 +575,12 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
           + newLine()
           + "=== Scenario: Failing icon:thumbs-down[role=\"red\",title=\"Failed\"]"
           + newLine()
           + "[small]#tags: @a,@c#"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -629,7 +588,6 @@ public interface Expectations {
           + newLine()
           + "this step fails icon:thumbs-down[role=\"red\",title=\"Failed\"] [small right]#(008ms)#"
           + newLine()
-          + ""
           + newLine()
           + "IMPORTANT:  (RuntimeError)"
           + newLine()
@@ -639,9 +597,7 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
-          + newLine()
-          + "";
+          + newLine();
 
   String DOCUMENTATION_WITHOUT_SCENARIO_KEYWORD =
       ":toc: left"
@@ -670,26 +626,21 @@ public interface Expectations {
           + newLine()
           + ":version-label: Version"
           + newLine()
-          + ""
           + newLine()
           + "= *Living Documentation*"
           + newLine()
-          + ""
           + newLine()
           + "include::"
           + home()
           + "cukedoctor-intro.adoc[leveloffset=+1]"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing"
           + " scenario]]"
           + newLine()
           + "== *One passing scenario, one failing scenario*"
           + newLine()
-          + ""
           + newLine()
           + "ifndef::backend-pdf[]"
           + newLine()
@@ -701,9 +652,7 @@ public interface Expectations {
           + newLine()
           + "[small]#tags: @a,@b#"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -714,15 +663,12 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
           + newLine()
           + "=== Failing icon:thumbs-down[role=\"red\",title=\"Failed\"]"
           + newLine()
           + "[small]#tags: @a,@c#"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -730,7 +676,6 @@ public interface Expectations {
           + newLine()
           + "this step fails icon:thumbs-down[role=\"red\",title=\"Failed\"] [small right]#(008ms)#"
           + newLine()
-          + ""
           + newLine()
           + "IMPORTANT:  (RuntimeError)"
           + newLine()
@@ -740,9 +685,7 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
-          + newLine()
-          + "";
+          + newLine();
 
   String DOCUMENTATION_WITHOUT_STEP_TIME =
       ":toc: left"
@@ -771,26 +714,21 @@ public interface Expectations {
           + newLine()
           + ":version-label: Version"
           + newLine()
-          + ""
           + newLine()
           + "= *Living Documentation*"
           + newLine()
-          + ""
           + newLine()
           + "include::"
           + home()
           + "cukedoctor-intro.adoc[leveloffset=+1]"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing"
           + " scenario]]"
           + newLine()
           + "== *One passing scenario, one failing scenario*"
           + newLine()
-          + ""
           + newLine()
           + "ifndef::backend-pdf[]"
           + newLine()
@@ -802,9 +740,7 @@ public interface Expectations {
           + newLine()
           + "[small]#tags: @a,@b#"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -814,15 +750,12 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
           + newLine()
           + "=== Scenario: Failing icon:thumbs-down[role=\"red\",title=\"Failed\"]"
           + newLine()
           + "[small]#tags: @a,@c#"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -830,7 +763,6 @@ public interface Expectations {
           + newLine()
           + "this step fails icon:thumbs-down[role=\"red\",title=\"Failed\"]"
           + newLine()
-          + ""
           + newLine()
           + "IMPORTANT:  (RuntimeError)"
           + newLine()
@@ -840,9 +772,7 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
-          + newLine()
-          + "";
+          + newLine();
 
   String DOCUMENTATION_WITHOUT_TAGS =
       ":toc: left"
@@ -871,26 +801,21 @@ public interface Expectations {
           + newLine()
           + ":version-label: Version"
           + newLine()
-          + ""
           + newLine()
           + "= *Living Documentation*"
           + newLine()
-          + ""
           + newLine()
           + "include::"
           + home()
           + "cukedoctor-intro.adoc[leveloffset=+1]"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing"
           + " scenario]]"
           + newLine()
           + "== *One passing scenario, one failing scenario*"
           + newLine()
-          + ""
           + newLine()
           + "ifndef::backend-pdf[]"
           + newLine()
@@ -900,7 +825,6 @@ public interface Expectations {
           + newLine()
           + "=== Scenario: Passing"
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -910,11 +834,9 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
           + newLine()
           + "=== Scenario: Failing icon:thumbs-down[role=\"red\",title=\"Failed\"]"
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -922,7 +844,6 @@ public interface Expectations {
           + newLine()
           + "this step fails icon:thumbs-down[role=\"red\",title=\"Failed\"]"
           + newLine()
-          + ""
           + newLine()
           + "IMPORTANT:  (RuntimeError)"
           + newLine()
@@ -932,9 +853,7 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
-          + newLine()
-          + "";
+          + newLine();
 
   String DOCUMENTATION_FOR_MULTIPLE_FEATURES =
       ":toc: left"
@@ -963,11 +882,9 @@ public interface Expectations {
           + newLine()
           + ":version-label: Version"
           + newLine()
-          + ""
           + newLine()
           + "= *Living Documentation*"
           + newLine()
-          + ""
           + newLine()
           + "include::"
           + home()
@@ -982,7 +899,6 @@ public interface Expectations {
           + newLine()
           + "3+|Scenarios 7+|Steps 2+|Features: 3"
           + newLine()
-          + ""
           + newLine()
           + "|[green]#*Passed*#"
           + newLine()
@@ -1008,9 +924,8 @@ public interface Expectations {
           + newLine()
           + "|Status"
           + newLine()
-          + ""
           + newLine()
-          + "12+^|*<<An-embed-data-directly-feature>>*"
+          + "12+^|*<<An-embed-data-directly-feature,An embed data directly feature>>*"
           + newLine()
           + "|3"
           + newLine()
@@ -1036,9 +951,8 @@ public interface Expectations {
           + newLine()
           + "|[green]#*passed*#"
           + newLine()
-          + ""
           + newLine()
-          + "12+^|*<<An-outline-feature>>*"
+          + "12+^|*<<An-outline-feature,An outline feature>>*"
           + newLine()
           + "|0"
           + newLine()
@@ -1064,9 +978,9 @@ public interface Expectations {
           + newLine()
           + "|[green]#*passed*#"
           + newLine()
-          + ""
           + newLine()
-          + "12+^|*<<One-passing-scenario-one-failing-scenario>>*"
+          + "12+^|*<<One-passing-scenario-one-failing-scenario,One passing scenario, one failing"
+          + " scenario>>*"
           + newLine()
           + "|1"
           + newLine()
@@ -1098,17 +1012,14 @@ public interface Expectations {
           + newLine()
           + "|==="
           + newLine()
-          + ""
           + newLine()
           + "== *Features*"
           + newLine()
-          + ""
           + newLine()
           + "[[An-embed-data-directly-feature, An embed data directly feature]]"
           + newLine()
           + "=== *An embed data directly feature*"
           + newLine()
-          + ""
           + newLine()
           + "ifndef::backend-pdf[]"
           + newLine()
@@ -1118,7 +1029,6 @@ public interface Expectations {
           + newLine()
           + "==== Scenario: scenario 1"
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -1129,11 +1039,9 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
           + newLine()
           + "==== Scenario Outline: scenario 2"
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -1144,9 +1052,7 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -1157,13 +1063,11 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
           + newLine()
           + "[[An-outline-feature, An outline feature]]"
           + newLine()
           + "=== *An outline feature*"
           + newLine()
-          + ""
           + newLine()
           + "ifndef::backend-pdf[]"
           + newLine()
@@ -1173,9 +1077,7 @@ public interface Expectations {
           + newLine()
           + "==== Scenario Outline: outline icon:thumbs-down[role=\"red\",title=\"Failed\"]"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + ".examples1"
           + newLine()
@@ -1191,7 +1093,6 @@ public interface Expectations {
           + newLine()
           + "|==="
           + newLine()
-          + ""
           + newLine()
           + ".examples2"
           + newLine()
@@ -1205,14 +1106,12 @@ public interface Expectations {
           + newLine()
           + "|==="
           + newLine()
-          + ""
           + newLine()
           + "[[One-passing-scenario-one-failing-scenario, One passing scenario, one failing"
           + " scenario]]"
           + newLine()
           + "=== *One passing scenario, one failing scenario*"
           + newLine()
-          + ""
           + newLine()
           + "ifndef::backend-pdf[]"
           + newLine()
@@ -1224,9 +1123,7 @@ public interface Expectations {
           + newLine()
           + "[small]#tags: @a,@b#"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -1237,15 +1134,12 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
           + newLine()
           + "==== Scenario: Failing icon:thumbs-down[role=\"red\",title=\"Failed\"]"
           + newLine()
           + "[small]#tags: @a,@c#"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -1253,7 +1147,6 @@ public interface Expectations {
           + newLine()
           + "this step fails icon:thumbs-down[role=\"red\",title=\"Failed\"] [small right]#(008ms)#"
           + newLine()
-          + ""
           + newLine()
           + "IMPORTANT:  (RuntimeError)"
           + newLine()
@@ -1263,9 +1156,7 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
-          + newLine()
-          + "";
+          + newLine();
 
   String FEATURE_WITH_STEP_TABLE_IN_PT_BR =
       ":toc: right"
@@ -1294,17 +1185,14 @@ public interface Expectations {
           + newLine()
           + ":version-label: Version"
           + newLine()
-          + ""
           + newLine()
           + "= *Doc Title*"
           + newLine()
-          + ""
           + newLine()
           + "include::"
           + home()
           + "cukedoctor-intro.adoc[leveloffset=+1]"
           + newLine()
-          + ""
           + newLine()
           + "== *Resumo*"
           + newLine()
@@ -1314,7 +1202,6 @@ public interface Expectations {
           + newLine()
           + "3+|Cenários 7+|Passos 2+|Funcionalidades: 1"
           + newLine()
-          + ""
           + newLine()
           + "|[green]#*Sucesso*#"
           + newLine()
@@ -1340,9 +1227,8 @@ public interface Expectations {
           + newLine()
           + "|Status"
           + newLine()
-          + ""
           + newLine()
-          + "12+^|*<<Search>>*"
+          + "12+^|*<<Search,Search>>*"
           + newLine()
           + "|1"
           + newLine()
@@ -1374,17 +1260,14 @@ public interface Expectations {
           + newLine()
           + "|==="
           + newLine()
-          + ""
           + newLine()
           + "== *Funcionalidades*"
           + newLine()
-          + ""
           + newLine()
           + "[[Search, Search]]"
           + newLine()
           + "=== *Search*"
           + newLine()
-          + ""
           + newLine()
           + "ifndef::backend-pdf[]"
           + newLine()
@@ -1396,9 +1279,7 @@ public interface Expectations {
           + newLine()
           + "[small]#tags: @txn#"
           + newLine()
-          + ""
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -1407,7 +1288,6 @@ public interface Expectations {
           + "a User has posted the following messages:"
           + " icon:thumbs-up[role=\"green\",title=\"Passed\"] [small right]#(111ms)#"
           + newLine()
-          + ""
           + newLine()
           + "[cols=\"1*\", options=\"header\"]"
           + newLine()
@@ -1423,11 +1303,9 @@ public interface Expectations {
           + newLine()
           + "|==="
           + newLine()
-          + ""
           + newLine()
           + "----"
           + newLine()
-          + ""
           + newLine()
           + "--"
           + newLine()
@@ -1435,27 +1313,21 @@ public interface Expectations {
           + newLine()
           + "--"
           + newLine()
-          + ""
           + newLine()
           + "----"
           + newLine()
           + "=========="
           + newLine()
-          + ""
-          + newLine()
-          + "";
+          + newLine();
   String DOCUMENTATION_WITH_SCENARIO_WITHOUT_DESCRIPTION =
-      ""
-          + newLine()
+      newLine()
           + "= *Documentation*"
           + newLine()
-          + ""
           + newLine()
           + "include::"
           + home()
           + "cukedoctor-intro.adoc[leveloffset=+1]"
           + newLine()
-          + ""
           + newLine()
           + "== *Summary*"
           + newLine()
@@ -1465,7 +1337,6 @@ public interface Expectations {
           + newLine()
           + "3+|Scenarios 7+|Steps 2+|Features: 1"
           + newLine()
-          + ""
           + newLine()
           + "|[green]#*Passed*#"
           + newLine()
@@ -1491,9 +1362,8 @@ public interface Expectations {
           + newLine()
           + "|Status"
           + newLine()
-          + ""
           + newLine()
-          + "12+^|*<<Do-something>>*"
+          + "12+^|*<<Do-something,Do something>>*"
           + newLine()
           + "|1"
           + newLine()
@@ -1525,17 +1395,14 @@ public interface Expectations {
           + newLine()
           + "|==="
           + newLine()
-          + ""
           + newLine()
           + "== *Features*"
           + newLine()
-          + ""
           + newLine()
           + "[[Do-something, Do something]]"
           + newLine()
           + "=== *Do something*"
           + newLine()
-          + ""
           + newLine()
           + "****"
           + newLine()
@@ -1543,11 +1410,9 @@ public interface Expectations {
           + newLine()
           + "****"
           + newLine()
-          + ""
           + newLine()
           + "==== Scenario: User browses to the site successfully"
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -1558,16 +1423,13 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
-          + newLine()
-          + "";
+          + newLine();
 
   String FEATURE_WITH_SOURCE_DOC_STRING =
       "[[test, test]]"
           + newLine()
           + "=== *test*"
           + newLine()
-          + ""
           + newLine()
           + "ifndef::backend-pdf[]"
           + newLine()
@@ -1577,7 +1439,6 @@ public interface Expectations {
           + newLine()
           + "==== Scenario: test icon:thumbs-down[role=\"red\",title=\"Failed\"]"
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -1589,7 +1450,6 @@ public interface Expectations {
           + newLine()
           + "----"
           + newLine()
-          + ""
           + newLine()
           + "class TestClass"
           + newLine()
@@ -1597,7 +1457,6 @@ public interface Expectations {
           + newLine()
           + "end"
           + newLine()
-          + ""
           + newLine()
           + "----"
           + newLine()
@@ -1632,17 +1491,14 @@ public interface Expectations {
           + newLine()
           + ":version-label: Version"
           + newLine()
-          + ""
           + newLine()
           + "= *Doc Title*"
           + newLine()
-          + ""
           + newLine()
           + "include::"
           + home()
           + "cukedoctor-intro.adoc[leveloffset=+1]"
           + newLine()
-          + ""
           + newLine()
           + "== *Summary*"
           + newLine()
@@ -1652,7 +1508,6 @@ public interface Expectations {
           + newLine()
           + "3+|Scenarios 7+|Steps 2+|Features: 1"
           + newLine()
-          + ""
           + newLine()
           + "|[green]#*Passed*#"
           + newLine()
@@ -1678,9 +1533,8 @@ public interface Expectations {
           + newLine()
           + "|Status"
           + newLine()
-          + ""
           + newLine()
-          + "12+^|*<<Echoing-a-message>>*"
+          + "12+^|*<<Echoing-a-message,Echoing a message>>*"
           + newLine()
           + "|1"
           + newLine()
@@ -1712,17 +1566,14 @@ public interface Expectations {
           + newLine()
           + "|==="
           + newLine()
-          + ""
           + newLine()
           + "== *Features*"
           + newLine()
-          + ""
           + newLine()
           + "[[Echoing-a-message, Echoing a message]]"
           + newLine()
           + "=== *Echoing a message*"
           + newLine()
-          + ""
           + newLine()
           + "ifndef::backend-pdf[]"
           + newLine()
@@ -1740,11 +1591,9 @@ public interface Expectations {
           + newLine()
           + "****"
           + newLine()
-          + ""
           + newLine()
           + "==== Scenario: Receive an echo of a message sent through the API"
           + newLine()
-          + ""
           + newLine()
           + "=========="
           + newLine()
@@ -1770,6 +1619,5 @@ public interface Expectations {
           + newLine()
           + "=========="
           + newLine()
-          + ""
           + newLine();
 }

--- a/cukedoctor-converter/src/test/resources/com/github/cukedoctor/bdd/cukedoctor/converter.feature
+++ b/cukedoctor-converter/src/test/resources/com/github/cukedoctor/bdd/cukedoctor/converter.feature
@@ -65,7 +65,7 @@ NOTE: *plugin* option replaced *format* option which was deprecated in newer cuc
 |Duration
 |Status
 
-12+^|*<<Feature1>>*
+12+^|*<<Feature1,Feature1>>*
 |1
 |0
 |1
@@ -79,7 +79,7 @@ NOTE: *plugin* option replaced *format* option which was deprecated in newer cuc
 |647ms
 |[green]#*passed*#
 
-12+^|*<<Feature2>>*
+12+^|*<<Feature2,Feature2>>*
 |1
 |0
 |1

--- a/cukedoctor-converter/src/test/resources/com/github/cukedoctor/bdd/cukedoctor/intro-chapter.feature
+++ b/cukedoctor-converter/src/test/resources/com/github/cukedoctor/bdd/cukedoctor/intro-chapter.feature
@@ -88,7 +88,7 @@ Here are some design principles:
 |Duration
 |Status
 
-12+^|*<<Feature1>>*
+12+^|*<<Feature1,Feature1>>*
 |1
 |0
 |1
@@ -102,7 +102,7 @@ Here are some design principles:
 |647ms
 |[green]#*passed*#
 
-12+^|*<<Feature2>>*
+12+^|*<<Feature2,Feature2>>*
 |1
 |0
 |1

--- a/cukedoctor-main/src/test/resources/features/cukedoctor_main.feature
+++ b/cukedoctor-main/src/test/resources/features/cukedoctor_main.feature
@@ -44,7 +44,7 @@ Feature: Cukedoctor Main
 |Duration
 |Status
 
-12+^|*<<One-passing-scenario-one-failing-scenario>>*
+12+^|*<<One-passing-scenario-one-failing-scenario,One passing scenario, one failing scenario>>*
 |1
 |1
 |2
@@ -136,7 +136,7 @@ features/one_passing_one_failing.feature:10:in Given this step fails'
 |Duration
 |Status
 
-12+^|*<<A-feature-with-a-diagram>>*
+12+^|*<<A-feature-with-a-diagram,A feature with a diagram>>*
 |1
 |0
 |1
@@ -150,7 +150,7 @@ features/one_passing_one_failing.feature:10:in Given this step fails'
 |001ms
 |[green]#*passed*#
 
-12+^|*<<An-embed-data-directly-feature>>*
+12+^|*<<An-embed-data-directly-feature,An embed data directly feature>>*
 |3
 |0
 |3
@@ -164,7 +164,7 @@ features/one_passing_one_failing.feature:10:in Given this step fails'
 |000ms
 |[green]#*passed*#
 
-12+^|*<<An-outline-feature>>*
+12+^|*<<An-outline-feature, An outline feature>>*
 |0
 |0
 |0
@@ -178,7 +178,7 @@ features/one_passing_one_failing.feature:10:in Given this step fails'
 |000ms
 |[green]#*passed*#
 
-12+^|*<<One-passing-scenario-one-failing-scenario>>*
+12+^|*<<One-passing-scenario-one-failing-scenario,One passing scenario, one failing scenario>>*
 |1
 |1
 |2
@@ -192,7 +192,7 @@ features/one_passing_one_failing.feature:10:in Given this step fails'
 |010ms
 |[red]#*failed*#
 
-12+^|*<<Sample-test>>*
+12+^|*<<Sample-test,Sample test>>*
 |1
 |1
 |2


### PR DESCRIPTION
Hi all,
I was generating documentation in French language and quotes appear quite often in titles.

Problem is that quotes don't play well with asciidoctor unique ids.

I remember having applied such a fix to feature ids, but never did on summary references.

So, to avoid the problem, I've applied the same rule of thumb:
* ids don't contain special characters
* asciidoc links from references or cross links should be labeled

For instance:

* Feature `One failing scenario` becomes link `<<One-failing-scenario,One failing scenario>>`
* Feature `Accéder à l'application` becomes link `<<Accéder-à-l-application,Accéder à l'application>>`

Here's the fix that reflects on this issue.

PS: my IntelliJ keeps complaining that there are empty quotes, resulting in performance loss. So I also removed them from where I changed code.